### PR TITLE
FOAM models for browser, web interface and browser APIs

### DIFF
--- a/lib/web_apis/browser.es6.js
+++ b/lib/web_apis/browser.es6.js
@@ -1,0 +1,66 @@
+/**
+ * @license
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the 'License');
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an 'AS IS' BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+foam.CLASS({
+  name: 'Browser',
+  package: 'com.web.api',
+  properties: [
+    {
+      name: 'browserName',
+      required: true,
+    },
+    {
+      name: 'browserVersion',
+      required: true,
+    },
+    {
+      name: 'OS',
+      required: true,
+    },
+    {
+      name: 'OSVersion',
+      required: true,
+    },
+    {
+      name: 'id',
+    },
+  ],
+  methods: [
+    {
+      name: 'init',
+      document: `After the browser object is created, hashCode function is
+        used to assign this browser a unique browser id`,
+      code: function() {
+        this.id = foam.util.hashCode(this);
+      },
+    },
+    {
+      name: 'getBrowserKey',
+      documentation: `Get the key of this browser, including browser name,
+        browser version, OS and OS version.`,
+      returns: {
+        documentation: `The key of this browser.`,
+        typeName: `String`,
+      },
+      code: function() {
+        return [this.browserName, this.browserVersion, this.OS,
+          this.OSVersion].join('_');
+      },
+    },
+  ],
+});

--- a/lib/web_apis/browser_api.es6.js
+++ b/lib/web_apis/browser_api.es6.js
@@ -1,0 +1,27 @@
+/**
+ * @license
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the 'License');
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an 'AS IS' BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+foam.CLASS({
+  name: 'BrowserAPI',
+  package: 'com.web.api',
+  properties: [
+    'id',
+    'browserId',
+    'interfaceId',
+  ],
+});

--- a/lib/web_apis/web_apis.es6.js
+++ b/lib/web_apis/web_apis.es6.js
@@ -1,0 +1,348 @@
+/**
+ * @license
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the 'License');
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an 'AS IS' BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+require('./browser.es6');
+require('./browser_api.es6');
+require('./web_interface.es6');
+
+foam.CLASS({
+  name: 'WebAPIs',
+  package: 'com.web.api',
+  requires: [
+    'com.web.api.Browser',
+    'com.web.api.BrowserAPI',
+    'com.web.api.WebInterface',
+    'foam.dao.EasyDAO',
+    'foam.mlang.sink.GroupBy',
+    'foam.dao.ArrayDAO',
+    'foam.mlang.ExpressionsSingleton',
+  ],
+  properties: [
+    {
+      name: 'browserAPIs',
+      documentation: `A DAO that contains pairs of browser Id
+        and interface Id.`,
+      factory: function() {
+        return this.EasyDAO.create({
+          name: 'BrowserAPIDAO',
+          of: this.BrowserAPI,
+          daoType: 'MDAO',
+        });
+      },
+    },
+    {
+      name: 'browsers',
+      documentation: `A DAO that contains browser names, versions
+        OS, OS versions and their browser Id.`,
+      factory: function() {
+        return this.EasyDAO.create({
+          name: 'BrowserDAO',
+          of: this.Browser,
+          daoType: 'MDAO',
+        });
+      },
+    },
+    {
+      name: 'interfaces',
+      documentation: `A DAO that contains interface names, API names,
+        and their interfaceId`,
+      factory: function() {
+        return this.EasyDAO.create({
+          name: 'InterfaceDAO',
+          of: this.WebInterface,
+          daoType: 'MDAO',
+        });
+      },
+    },
+    {
+      name: 'mlang',
+      factory: function() {
+        return this.ExpressionsSingleton.create();
+      },
+    },
+  ],
+  methods: [
+    {
+      name: 'importAPI',
+      documentation: 'Import interface/API for a given version of browser.',
+      args: [
+        {
+          name: 'browserName',
+          documentation: `The name of imported browser.`,
+          typeName: 'String',
+        },
+        {
+          name: 'browserVersion',
+          documentation: `The version of imported browser.`,
+          typeName: 'String',
+        },
+        {
+          name: 'OSName',
+          documentation: `The name of operating system.`,
+          typeName: 'String',
+        },
+        {
+          name: 'OSVersion',
+          documentation: `The version of operating system.`,
+          typeName: 'String',
+        },
+        {
+          name: 'apiCatalog',
+          documentation: `The web catalog of this version of
+            browser, tested on the given operating system and version.
+            The json object should be the JSON object returned from
+            com.web.catalog.apiExtractor`,
+          typeName: 'JSON',
+        },
+      ],
+      code: function(browserName, browserVersion,
+        OSName, OSVersion, apiCatalog) {
+        let browser = this.Browser.create({
+          browserName: browserName,
+          browserVersion: browserVersion,
+          OS: OSName,
+          OSVersion: OSVersion,
+        });
+        let browserId = browser.id;
+        // Check?
+        this.browsers.put(browser);
+        let interfaceNames = Object.keys(apiCatalog);
+        for (let i = 0; i < interfaceNames.length; i += 1) {
+          let interfaceName = interfaceNames[i];
+          for (let j = 0; j < apiCatalog[interfaceName].length; j += 1) {
+            let APIName = apiCatalog[interfaceName][j];
+            let webInterface = this.WebInterface.create({
+              interfaceName,
+              APIName,
+            });
+            let interfaceId = webInterface.id;
+            this.interfaces.put(webInterface);
+            this.browserAPIs.put(this.BrowserAPI.create({
+              browserId,
+              interfaceId,
+              id: `${browserId}.${interfaceId}`,
+            }));
+          }
+        }
+      },
+    },
+    {
+      name: 'getBrowserKeys',
+      documentation: `Asynch function to return an array of stored
+        browsers' key. browserName and version are optional arguments
+        to filter keys.`,
+      args: [
+        {
+          name: 'browserName',
+          documentation: `The optional argument that the returned browser
+            key will match the given name`,
+          typeName: 'String',
+        },
+        {
+          name: 'version',
+          documentation: `The optional argument that the returned browser
+            key will match the given version`,
+          typeName: 'String',
+        },
+      ],
+      returns: {
+        typeName: 'StringArray',
+        documentation: `Return a string array contains matching browser keys`,
+      },
+      code: function(browserName, version) {
+        return new Promise((resolve) => {
+          this.browsers.select().then((arrayDAO) => {
+            resolve(arrayDAO.a
+            .map((browser) => browser.getBrowserKey())
+            .filter((key) => {
+              if (browserName &&
+              key.split('_')[0].indexOf(browserName) !== 0) {
+                return false;
+              }
+              if (version &&
+              key.split('_')[1].indexOf(version) !== 0) {
+                return false;
+              }
+              return true;
+            }));
+          });
+        });
+      },
+    },
+    {
+      name: 'getBrowserId_',
+      args: [
+        {
+          name: 'browserKey',
+          typeName: 'String',
+          documentation: `The string must be a key of browser`,
+        },
+      ],
+      returns: {
+        typeName: 'Number',
+        documentation: `The id of this browser`,
+      },
+      code: function(browserKey) {
+        let browserArr = browserKey.split('_');
+        return this.Browser.create({
+          browserName: browserArr[0],
+          browserVersion: browserArr[1],
+          OS: browserArr[2],
+          OSVersion: browserArr[3],
+        }).id;
+      },
+    },
+    {
+      name: 'toMap_',
+      documentation: `Takes an array of browserAPIs and an array of
+        browser keys, produce a JSON containing browser and interface
+        relationship`,
+      args: [
+        {
+          name: 'browserAPIs',
+          typeName: 'BrowserAPI Array',
+          documentation: `An array returned from DAO.select.`,
+        },
+        {
+          name: 'brwoserKeys',
+          typeName: 'StringArray',
+          documentation: `A list of browser keys that contained in the
+            browserAPIs`,
+        },
+      ],
+      returns: {
+        typeName: 'JSON',
+        documentation: `Returns a JSON of the form:
+              {interfaceName: {APIName: [Boolean ...]} ...}
+            It contains information about browsers and their interface/API.`,
+      },
+      code: function(browserAPIs, browserKeys) {
+        return new Promise(function(resolve) {
+          let apiMap = {};
+          let browserDict = {}; // O(1) lookup for browser's index in header.
+          apiMap._header = browserKeys.slice();
+          let numBrowsers = apiMap._header.length;
+          // Fill in browserDict.
+          for (let i = 0; i < numBrowsers; i += 1) {
+            browserDict[this.getBrowserId_(browserKeys[i])] = i;
+          }
+          // Fill in apiMap.
+          let promises = [];
+          for (let i = 0; i < browserAPIs.length; i += 1) {
+            let interfaceId = browserAPIs[i].interfaceId;
+            promises.push(this.interfaces
+              .where(this.mlang.EQ(this.WebInterface.ID, interfaceId)).select()
+              .then((arrayDao) => {
+                let interfaceName = arrayDao.a[0].interfaceName;
+                let APIName = arrayDao.a[0].APIName;
+                if (!apiMap[interfaceName] ||
+                  typeof apiMap[interfaceName] !== 'object') {
+                  // If typeof is not object, this may be a build-in function.
+                  apiMap[interfaceName] = {};
+                }
+                if (!apiMap[interfaceName][APIName] ||
+                  typeof apiMap[interfaceName][APIName] !== 'object') {
+                  // If visit APIName for first time,
+                  // initialize an array of false.
+                  apiMap[interfaceName][APIName] = [];
+                  for (let k = 0; k < numBrowsers; k += 1) {
+                    apiMap[interfaceName][APIName].push(false);
+                  }
+                }
+                apiMap[interfaceName][APIName][
+                  browserDict[browserAPIs[i].browserId]] = true;
+              }));
+          }
+          Promise.all(promises).then(function() {
+            resolve(apiMap);
+          });
+        }.bind(this));
+      },
+    },
+    {
+      name: 'toMap',
+      documentation: `Takes an array of browser keys, produce a JSON containing
+        browser and interface relationship`,
+      args: [
+        {
+          name: 'browserKeys',
+          typeName: 'StringArray',
+          documentation: `A string array contains valid browser keys`,
+        },
+      ],
+      returns: {
+        typeName: 'JSON',
+        documentation: `Returns a JSON of the form:
+                {interfaceName: {APIName: [Boolean ...]} ...}`,
+      },
+      code: function(browserKeys) {
+        return new Promise(function(resolve) {
+          let browserIds = browserKeys.map((key) => this.getBrowserId_(key));
+          this.browserAPIs
+            .where(this.mlang.IN(this.BrowserAPI.BROWSER_ID, browserIds))
+            .select()
+            .then((arrayDao) => {
+              resolve(this.toMap_(arrayDao.a, browserKeys));
+            });
+        }.bind(this));
+      },
+    },
+    {
+      name: 'toCSV',
+      documentation: `Takes an array of browser keys, produce a String of
+        CSV format`,
+      args: [
+        {
+          name: 'browserKeys',
+          typeName: 'StringArray',
+          documentation: `A string array contains valid browser keys`,
+        },
+      ],
+      returns: {
+        typeName: 'String',
+        documentation: `Returns a string of csv format`,
+      },
+      code: function(browserKeys) {
+        return new Promise(function(resolve) {
+          this.toMap(browserKeys).then(function(result) {
+            let table = [];
+            // Add table header.
+            table.push(['Interface', 'API'].concat(result._header));
+            let interfaces = Object.keys(result);
+            for (let i = 0; i < interfaces.length; i += 1) {
+              let interfaceName = interfaces[i];
+              if (interfaceName === '_header') continue;
+              let APIs = Object.keys(result[interfaceName]);
+              for (let j = 0; j < APIs.length; j += 1) {
+                let APIName = APIs[j];
+                table.push([interfaceName, APIName]
+                  .concat(result[interfaceName][APIName]));
+              }
+            }
+            let csv = '';
+            for (let i = 0; i < table.length; i += 1) {
+              csv += table[i].join(',');
+              csv += '\n';
+            }
+            resolve(csv);
+          });
+        }.bind(this));
+      },
+    },
+  ],
+});

--- a/lib/web_apis/web_apis.es6.js
+++ b/lib/web_apis/web_apis.es6.js
@@ -119,7 +119,6 @@ foam.CLASS({
           OSVersion: OSVersion,
         });
         let browserId = browser.id;
-        // Check?
         this.browsers.put(browser);
         let interfaceNames = Object.keys(apiCatalog);
         for (let i = 0; i < interfaceNames.length; i += 1) {

--- a/lib/web_apis/web_interface.es6.js
+++ b/lib/web_apis/web_interface.es6.js
@@ -1,3 +1,21 @@
+/**
+ * @license
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the 'License');
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an 'AS IS' BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
 foam.CLASS({
   name: 'WebInterface',
   package: 'com.web.api',

--- a/lib/web_apis/web_interface.es6.js
+++ b/lib/web_apis/web_interface.es6.js
@@ -1,0 +1,19 @@
+foam.CLASS({
+  name: 'WebInterface',
+  package: 'com.web.api',
+  properties: [
+    'interfaceName',
+    'APIName',
+    'id',
+  ],
+  methods: [
+    {
+      name: 'init',
+      document: `After the WebInterface is created, hashCode function is used
+        to assign this browser a unique browser id`,
+      code: function() {
+        this.id = foam.util.hashCode(this);
+      },
+    },
+  ],
+});

--- a/lib/web_catalog/api_extractor.es6.js
+++ b/lib/web_catalog/api_extractor.es6.js
@@ -423,7 +423,6 @@ foam.CLASS({
         // even they reference to the same object.
         // For __proto__ objects, if they are visited as a not first-level
         // or proto objects before, we will miss capturing them.
-        console.log(id, proto);
         if (visited.hasOwnProperty(id) && !firstLevel && !proto) return;
 
         // Return if this object is a primitive type.

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "description": "Web API Confluence Dashboard",
   "scripts": {
-    "test": "karma start ./config/karma.all.conf.js"
+    "test": "karma start ./config/karma.all.conf.js",
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "description": "Web API Confluence Dashboard",
   "scripts": {
-    "test": "karma start ./config/karma.all.conf.js",
+    "test": "karma start ./config/karma.all.conf.js"
   },
   "repository": {
     "type": "git",

--- a/test/any/web_apis/browser-test.es6.js
+++ b/test/any/web_apis/browser-test.es6.js
@@ -1,0 +1,78 @@
+/**
+ * @license
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the 'License');
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an 'AS IS' BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+describe('Browser', function() {
+  describe('browser id', function() {
+    it('returns same id for two identitical browsers', function() {
+      let chromeA = com.web.api.Browser.create({
+        browserName: 'Chrome',
+        browserVersion: '56',
+        OS: 'Windows',
+        OSVersion: '10',
+      }).id;
+      let chromeB = com.web.api.Browser.create({
+        browserName: 'Chrome',
+        browserVersion: '56',
+        OS: 'Windows',
+        OSVersion: '10',
+      }).id;
+      expect(chromeA).toBe(chromeB);
+
+      let firefoxA = com.web.api.Browser.create({
+        browserName: 'Firefox',
+        browserVersion: '50',
+        OS: 'OSX',
+        OSVersion: '10.11',
+      }).id;
+      let firefoxB = com.web.api.Browser.create({
+        browserName: 'Firefox',
+        browserVersion: '50',
+        OS: 'OSX',
+        OSVersion: '10.11',
+      }).id;
+      expect(firefoxA).toBe(firefoxB);
+    });
+  });
+  describe('getBrowserKey', function() {
+    it('returns the correct key for any browsers', function() {
+      let chrome57Key = com.web.api.Browser.create({
+        browserName: 'Chrome',
+        browserVersion: '57',
+        OS: 'OSX',
+        OSVersion: '10.11',
+      }).getBrowserKey();
+      expect(chrome57Key).toBe('Chrome_57_OSX_10.11');
+
+      let Safari602Key = com.web.api.Browser.create({
+        browserName: 'Safari',
+        browserVersion: '602.4.8',
+        OS: 'OSX',
+        OSVersion: '10.12.3',
+      }).getBrowserKey();
+      expect(Safari602Key).toBe('Safari_602.4.8_OSX_10.12.3');
+
+      let Edge12Key = com.web.api.Browser.create({
+        browserName: 'Edge',
+        browserVersion: '12',
+        OS: 'Windows',
+        OSVersion: '10',
+      }).getBrowserKey();
+      expect(Edge12Key).toBe('Edge_12_Windows_10');
+    });
+  });
+});

--- a/test/any/web_apis/web-apis-test.es6.js
+++ b/test/any/web_apis/web-apis-test.es6.js
@@ -1,0 +1,385 @@
+/**
+ * @license
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the 'License');
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an 'AS IS' BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+describe('WebAPIs', function() {
+  let webAPIs = com.web.api.WebAPIs.create();
+  let M = foam.mlang.ExpressionsSingleton.create();
+  let webCatalog = {
+    'Window': [
+      'Function',
+      'property',
+    ],
+    'Function': [
+      'arguments',
+      'caller',
+    ],
+  };
+  webAPIs.importAPI('Chrome', '56.0.2924.87', 'OSX', '10.12.2', webCatalog);
+
+  describe('importAPI()', function() {
+    it('correctly imports browser object', function(done) {
+      webAPIs.browsers.where(M.AND(
+        M.EQ(com.web.api.Browser.BROWSER_NAME, 'Chrome'),
+        M.EQ(com.web.api.Browser.BROWSER_VERSION, '56.0.2924.87'),
+        M.EQ(com.web.api.Browser.OS, 'OSX'),
+        M.EQ(com.web.api.Browser.OSVERSION, '10.12.2'))).select()
+      .then((arrayDAO) => {
+        expect(arrayDAO.a.length).toBe(1);
+        done();
+      });
+    });
+    it('correctly imports WebInterface objects', function(done) {
+      let promises = [];
+      promises.push(webAPIs.interfaces.where(M.AND(
+          M.EQ(com.web.api.WebInterface.INTERFACE_NAME, 'Window'),
+          M.EQ(com.web.api.WebInterface.APINAME, 'Function')))
+        .select());
+      promises.push(webAPIs.interfaces.where(M.AND(
+          M.EQ(com.web.api.WebInterface.INTERFACE_NAME, 'Window'),
+          M.EQ(com.web.api.WebInterface.APINAME, 'property')))
+        .select());
+      promises.push(webAPIs.interfaces.where(M.AND(
+          M.EQ(com.web.api.WebInterface.INTERFACE_NAME, 'Function'),
+          M.EQ(com.web.api.WebInterface.APINAME, 'arguments')))
+        .select());
+      promises.push(webAPIs.interfaces.where(M.AND(
+          M.EQ(com.web.api.WebInterface.INTERFACE_NAME, 'Function'),
+          M.EQ(com.web.api.WebInterface.APINAME, 'caller')))
+        .select());
+      Promise.all(promises).then((results) => {
+        results.forEach((defaultArrayDAO) => {
+          expect(defaultArrayDAO.a.length).toBe(1);
+        });
+        done();
+      });
+    });
+    it('imports browser Id and Interface Id to BrowserAPIs', function(done) {
+      let browserId = com.web.api.Browser.create({
+        browserName: 'Chrome',
+        browserVersion: '56.0.2924.87',
+        OS: 'OSX',
+        OSVersion: '10.12.2',
+      }).id;
+      let interfaceIds = [
+        com.web.api.WebInterface.create({
+          interfaceName: 'Window',
+          APIName: 'Function',
+        }).id,
+        com.web.api.WebInterface.create({
+          interfaceName: 'Window',
+          APIName: 'property',
+        }).id,
+        com.web.api.WebInterface.create({
+          interfaceName: 'Function',
+          APIName: 'arguments',
+        }).id,
+        com.web.api.WebInterface.create({
+          interfaceName: 'Function',
+          APIName: 'caller',
+        }).id,
+      ];
+      let promises = interfaceIds.map((interfaceId) => {
+        return webAPIs.browserAPIs.where(M.AND(
+            M.EQ(com.web.api.BrowserAPI.BROWSER_ID, browserId),
+            M.EQ(com.web.api.BrowserAPI.INTERFACE_ID, interfaceId)
+          )).select();
+      });
+      Promise.all(promises).then((results) => {
+        results.forEach((defaultArrayDAO) => {
+          expect(defaultArrayDAO.a.length).toBe(1);
+        });
+        done();
+      });
+    });
+  });
+
+  webAPIs.importAPI('Chrome', '55.123.45', 'OSX', '10.12.2', webCatalog);
+  webAPIs.importAPI('Chrome', '55.321', 'Windows', '10', webCatalog);
+  webAPIs.importAPI('Chrome', '55.321', 'Windows', '8', webCatalog);
+  webAPIs.importAPI('Chrome', '55.321', 'Windows', '7', webCatalog);
+  webAPIs.importAPI('Firefox', '50', 'Windows', '10', webCatalog);
+  describe('getBrowserKeys()', function() {
+    it('returns all existing keys if no arguments are given', function(done) {
+      webAPIs.getBrowserKeys().then((keys) => {
+        expect(keys.sort()).toEqual([
+          'Chrome_56.0.2924.87_OSX_10.12.2',
+          'Chrome_55.123.45_OSX_10.12.2',
+          'Chrome_55.321_Windows_10',
+          'Chrome_55.321_Windows_8',
+          'Chrome_55.321_Windows_7',
+          'Firefox_50_Windows_10',
+          ].sort());
+        done();
+      });
+    });
+    it('returns keys for a specific browser if first argument is given',
+    function(done) {
+      webAPIs.getBrowserKeys('Chrome').then((keys) => {
+        expect(keys.sort()).toEqual([
+          'Chrome_56.0.2924.87_OSX_10.12.2',
+          'Chrome_55.123.45_OSX_10.12.2',
+          'Chrome_55.321_Windows_10',
+          'Chrome_55.321_Windows_8',
+          'Chrome_55.321_Windows_7',
+          ].sort());
+        done();
+      });
+    });
+    it(`returns keys for a specific browser and versions if two
+    argument are given`, function(done) {
+      webAPIs.getBrowserKeys('Chrome', '55').then((keys) => {
+        expect(keys.sort()).toEqual([
+          'Chrome_55.123.45_OSX_10.12.2',
+          'Chrome_55.321_Windows_10',
+          'Chrome_55.321_Windows_8',
+          'Chrome_55.321_Windows_7',
+          ].sort());
+        done();
+      });
+    });
+  });
+
+  describe('toMap_()', function() {
+    let webAPIs = com.web.api.WebAPIs.create();
+    webAPIs.importAPI('Chrome', '55', 'Window', '10', {
+      'Array': ['find'],
+      'Audio': ['stop'],
+    });
+    webAPIs.importAPI('Edge', '14', 'Window', '10', {
+      'Array': ['find'],
+      'Audio': ['play'],
+    });
+    webAPIs.importAPI('Safari', '10', 'OSX', '601', {
+      'ApplePay': ['about'],
+      'Audio': ['play', 'stop'],
+      'Array': ['find'],
+    });
+
+    describe('when all browser keys are selected', function() {
+      it(`contains all browser keys in header array`, function(done) {
+        webAPIs.browserAPIs.select().then((arrayDAO) => {
+          webAPIs.toMap_(arrayDAO.a, [
+            'Chrome_55_Window_10',
+            'Edge_14_Window_10',
+            'Safari_10_OSX_601',
+          ]).then((interfaceMap) => {
+            expect(interfaceMap._header).toEqual([
+              'Chrome_55_Window_10',
+              'Edge_14_Window_10',
+              'Safari_10_OSX_601',
+            ]);
+            done();
+          });
+        });
+      });
+      it(`contains correct interface and API information`, function(done) {
+        webAPIs.browserAPIs.select().then((arrayDAO) => {
+          webAPIs.toMap_(arrayDAO.a, [
+            'Chrome_55_Window_10',
+            'Edge_14_Window_10',
+            'Safari_10_OSX_601',
+          ]).then((interfaceMap) => {
+            expect(interfaceMap.ApplePay.about).toEqual([
+              false, false, true,
+            ]);
+            expect(interfaceMap.Array.find).toEqual([
+              true, true, true,
+            ]);
+            expect(interfaceMap.Audio.play).toEqual([
+              false, true, true,
+            ]);
+            expect(interfaceMap.Audio.stop).toEqual([
+              true, false, true,
+            ]);
+            done();
+          });
+        });
+      });
+    });
+    describe('when part of browser keys are selected', function() {
+      it(`contains selected browser keys in header`, function() {
+        webAPIs.browserAPIs.select().then((arrayDAO) => {
+          webAPIs.toMap_(arrayDAO.a, [
+            'Chrome_55_Window_10',
+            'Edge_14_Window_10',
+          ]).then((interfaceMap) => {
+            expect(interfaceMap._header).toEqual([
+              'Chrome_55_Window_10',
+              'Edge_14_Window_10',
+            ]);
+          });
+        });
+      });
+      it(`contains correct interface and API information`, function(done) {
+        webAPIs.browserAPIs.where(M.IN(com.web.api.BrowserAPI.BROWSER_ID,
+          [
+            webAPIs.getBrowserId_('Chrome_55_Window_10'),
+            webAPIs.getBrowserId_('Edge_14_Window_10'),
+          ])).select()
+        .then((arrayDAO) => {
+          webAPIs.toMap_(arrayDAO.a, [
+            'Chrome_55_Window_10',
+            'Edge_14_Window_10',
+          ]).then((interfaceMap) => {
+            expect(interfaceMap.Array.find).toEqual([
+              true, true,
+            ]);
+            expect(interfaceMap.Audio.play).toEqual([
+              false, true,
+            ]);
+            expect(interfaceMap.Audio.stop).toEqual([
+              true, false,
+            ]);
+            done();
+          });
+        });
+      });
+    });
+  });
+
+  describe('toMap()', function() {
+    let webAPIs = com.web.api.WebAPIs.create();
+    webAPIs.importAPI('Chrome', '55', 'Window', '10', {
+      'Array': ['find'],
+      'Audio': ['stop'],
+    });
+    webAPIs.importAPI('Edge', '14', 'Window', '10', {
+      'Array': ['find'],
+      'Audio': ['play'],
+    });
+    webAPIs.importAPI('Safari', '10', 'OSX', '601', {
+      'ApplePay': ['about'],
+      'Audio': ['play', 'stop'],
+      'Array': ['find'],
+    });
+    describe('When all browsers are selected', function() {
+      it(`contains all browser keys in header array`, function(done) {
+        webAPIs.toMap([
+          'Chrome_55_Window_10',
+          'Edge_14_Window_10',
+          'Safari_10_OSX_601',
+        ]).then((interfaceMap) => {
+          expect(interfaceMap._header).toEqual([
+            'Chrome_55_Window_10',
+            'Edge_14_Window_10',
+            'Safari_10_OSX_601',
+          ]);
+          done();
+        });
+      });
+      it(`contains correct interface and API information`, function(done) {
+        webAPIs.toMap([
+          'Chrome_55_Window_10',
+          'Edge_14_Window_10',
+          'Safari_10_OSX_601',
+        ]).then((interfaceMap) => {
+          expect(interfaceMap.ApplePay.about).toEqual([
+            false, false, true,
+          ]);
+          expect(interfaceMap.Array.find).toEqual([
+            true, true, true,
+          ]);
+          expect(interfaceMap.Audio.play).toEqual([
+            false, true, true,
+          ]);
+          expect(interfaceMap.Audio.stop).toEqual([
+            true, false, true,
+          ]);
+          done();
+        });
+      });
+    });
+    describe('when part of browser keys are selected', function() {
+      it(`contains selected browser keys in header`, function() {
+        webAPIs.toMap([
+          'Chrome_55_Window_10',
+          'Edge_14_Window_10',
+        ]).then((interfaceMap) => {
+          expect(interfaceMap._header).toEqual([
+            'Chrome_55_Window_10',
+            'Edge_14_Window_10',
+          ]);
+        });
+      });
+      it(`contains correct interface and API information`, function(done) {
+        webAPIs.toMap([
+          'Chrome_55_Window_10',
+          'Edge_14_Window_10',
+        ]).then((interfaceMap) => {
+          expect(interfaceMap.Array.find).toEqual([
+            true, true,
+          ]);
+          expect(interfaceMap.Audio.play).toEqual([
+            false, true,
+          ]);
+          expect(interfaceMap.Audio.stop).toEqual([
+            true, false,
+          ]);
+          done();
+        });
+      });
+    });
+  });
+
+  describe('toCSV()', function() {
+    let webAPIs = com.web.api.WebAPIs.create();
+    webAPIs.importAPI('Chrome', '55', 'Window', '10', {
+      'Array': ['find'],
+      'Audio': ['stop'],
+    });
+    webAPIs.importAPI('Edge', '14', 'Window', '10', {
+      'Array': ['find'],
+      'Audio': ['play'],
+    });
+    webAPIs.importAPI('Safari', '10', 'OSX', '601', {
+      'ApplePay': ['about'],
+      'Audio': ['play', 'stop'],
+      'Array': ['find'],
+    });
+    it(`produces correct csv string when all browsers are selected`,
+    function(done) {
+      webAPIs.toCSV([
+        'Chrome_55_Window_10',
+        'Edge_14_Window_10',
+        'Safari_10_OSX_601',
+      ]).then((csvStr) => {
+        expect(csvStr).toEqual(
+          'Interface,API,Chrome_55_Window_10,Edge_14_Window_10,' +
+          'Safari_10_OSX_601\n' + 'Array,find,true,true,true\n' +
+          'Audio,play,false,true,true\n' + 'Audio,stop,true,false,true\n' +
+          'ApplePay,about,false,false,true\n'
+        );
+        done();
+      });
+    });
+    it(`produces correct csv string when part of browsers are selected`,
+    function(done) {
+      webAPIs.toCSV([
+        'Chrome_55_Window_10',
+        'Edge_14_Window_10',
+      ]).then((csvStr) => {
+        expect(csvStr).toEqual(
+          'Interface,API,Chrome_55_Window_10,Edge_14_Window_10\n' +
+          'Array,find,true,true\n' + 'Audio,stop,true,false\n' +
+          'Audio,play,false,true\n'
+        );
+        done();
+      });
+    });
+  });
+});

--- a/test/any/web_apis/web-interface-test.es6.js
+++ b/test/any/web_apis/web-interface-test.es6.js
@@ -1,0 +1,43 @@
+/**
+ * @license
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the 'License');
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an 'AS IS' BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+describe('WebInterface', function() {
+  describe('Interface Id', function() {
+    it('returns same id for two identitical browsers', function() {
+      let interfaceAId = com.web.api.WebInterface.create({
+        interfaceName: 'AudioContext',
+        APIName: 'createBuffer',
+      }).id;
+      let interfaceBId = com.web.api.WebInterface.create({
+        interfaceName: 'AudioContext',
+        APIName: 'createBuffer',
+      }).id;
+      expect(interfaceAId).toBe(interfaceBId);
+
+      let interfaceCId = com.web.api.WebInterface.create({
+        interfaceName: 'console',
+        APIName: 'log',
+      }).id;
+      let interfaceDId = com.web.api.WebInterface.create({
+        interfaceName: 'console',
+        APIName: 'log',
+      }).id;
+      expect(interfaceCId).toBe(interfaceDId);
+    });
+  });
+});

--- a/test/browser/webpack-helper.js
+++ b/test/browser/webpack-helper.js
@@ -25,12 +25,10 @@
 /**
   @param {webpack-context} r - all files in the context will be loaded.
 */
-function importAll(r) {
-  r.keys().forEach(r);
-}
 
-// Import all libraries from lib directory.
-importAll(require.context(`${__dirname}/../../lib`, true, /\.js$/));
+// Import libraries to test.
+require('../../lib/web_catalog/api_extractor.es6');
+require('../../lib/web_apis/web_apis.es6');
 
 // Require external libraries.
 let libs = {


### PR DESCRIPTION
- FOAM models for browser, web interface and browsers added.
- Essential methods for webAPIs are added.
- Change webpack-helper.js to hardcoded require(), since require.context does not give any dependency options.