### PR TITLE
Change noActivityTimeout to be 150s.

### DIFF
--- a/config/karma.conf.js
+++ b/config/karma.conf.js
@@ -97,7 +97,7 @@ function configurator(config) {
     // how many browser should be started simultaneous
     concurrency: Infinity,
 
-    browserNoActivityTimeout: 60000,
+    browserNoActivityTimeout: 150000,
   });
 };
 


### PR DESCRIPTION
When browserNoActivityTimeout is 60 seconds, the travisCI test was broken with DISCONNECTED error.