### PR TITLE
Test aggressive removal

### DIFF
--- a/lib/client/api_matrix.es6.js
+++ b/lib/client/api_matrix.es6.js
@@ -11,12 +11,13 @@ foam.CLASS({
     to CSV format string or JSON matrix that can be displayed on HTML as
     a nested table.`,
   requires: [
-    'org.chromium.apis.web.Browser',
-    'org.chromium.apis.web.WebInterface',
-    'org.chromium.apis.web.BrowserWebInterfaceJunction',
-    'foam.dao.EasyDAO',
+    'foam.dao.AnonymousSink',
     'foam.dao.ArraySink',
+    'foam.dao.EasyDAO',
     'foam.mlang.ExpressionsSingleton',
+    'org.chromium.apis.web.Browser',
+    'org.chromium.apis.web.BrowserWebInterfaceJunction',
+    'org.chromium.apis.web.WebInterface',
   ],
   properties: [
     {
@@ -131,8 +132,8 @@ foam.CLASS({
             }
             // TODO(markdittmer): ContextualizingDAO should take care of this.
             return browser.cls_.create(browser, this.__subContext__)
-              .interfaces.where(query).select({
-                put: (_, iface) => {
+              .interfaces.where(query).select(this.AnonymousSink.create({
+                sink: {put: (_, iface) => {
                   let k0 = iface.interfaceName;
                   let k1 = iface.apiName;
                   let k2 = browserId;
@@ -151,8 +152,8 @@ foam.CLASS({
                     matrix[k0][k1] = {};
                   }
                   matrix[k0][k1][k2] = true;
-                },
-              });
+                }},
+              }));
             })
         )).then(() => this.filterMatrix_(matrix, options));
       },

--- a/lib/client/api_service.es6.js
+++ b/lib/client/api_service.es6.js
@@ -33,19 +33,19 @@ angular.module('confluence').service('api', ['$window', function($window) {
   promises.push(foam.dao.RestDAO.create({
     baseURL: BROWSER_URL,
     of: org.chromium.apis.web.Browser,
-  }).select({
-    put: (_, browser) => {
+  }).select(foam.dao.AnonymousSink.create({
+    sink: {put: (_, browser) => {
       browserDAO.put(browser);
-    },
-  }));
+    }},
+  })));
   promises.push(foam.dao.RestDAO.create({
     baseURL: WEB_INTERFACE_URL,
     of: org.chromium.apis.web.WebInterface,
-  }).select({
-    put: (_, webInterface) => {
+  }).select(foam.dao.AnonymousSink.create({
+    sink: {put: (_, webInterface) => {
       interfaceDAO.put(webInterface);
-    },
-  }));
+    }},
+  })));
   let apiMatrix = org.chromium.apis.web.ApiMatrix.create({
     browserApiDAO,
     browserDAO,

--- a/lib/confluence/aggressive_removal.es6.js
+++ b/lib/confluence/aggressive_removal.es6.js
@@ -14,13 +14,14 @@ foam.CLASS({
     that is removed in this browser at least 1 years ago but still exists in
     other browsers.`,
   requires: [
-    'org.chromium.apis.web.Browser',
-    'org.chromium.apis.web.WebInterface',
-    'org.chromium.apis.web.BrowserWebInterfaceJunction',
-    'org.chromium.apis.web.AggressiveRemovalData',
-    'foam.mlang.ExpressionsSingleton',
+    'foam.dao.AnonymousSink',
     'foam.dao.ArraySink',
     'foam.dao.EasyDAO',
+    'foam.mlang.ExpressionsSingleton',
+    'org.chromium.apis.web.AggressiveRemovalData',
+    'org.chromium.apis.web.Browser',
+    'org.chromium.apis.web.BrowserWebInterfaceJunction',
+    'org.chromium.apis.web.WebInterface',
   ],
   properties: [
     {
@@ -66,58 +67,70 @@ foam.CLASS({
             if (prevReleaseBrowsers.length < 2)
               return Promise.resolve(this.ArraySink.create());
 
-            let browser = prevReleaseBrowsers.pop();
+            // TODO(markdittmer): This assumes that browsers are in
+            // releaseDate-order. That assumption doesn't appear to be
+            // documented or enforced.
+            let latestPrevReleaseBrowser = prevReleaseBrowsers.pop();
             let removedIfaces = {};
             let promises = [];
-            // Find all APIs available this browser before date - 1yr.
+            // Find all APIs available this browser before date -1yr.
             for (let i = 0; i < prevReleaseBrowsers.length; i++) {
-              promises.push(prevReleaseBrowsers[i].interfaces.select({
-                put: function(_, iface) {
-                  if (!removedIfaces.hasOwnProperty(iface.interfaceKey)) {
-                    removedIfaces[iface.interfaceKey] = 0;
-                  }
-                },
-              }));
+              promises.push(prevReleaseBrowsers[i].interfaces.select(
+                  this.AnonymousSink.create({sink: {put: function(_, iface) {
+                    if (!removedIfaces.hasOwnProperty(iface.interfaceKey)) {
+                      removedIfaces[iface.interfaceKey] = 0;
+                    }
+                  }}})));
             }
-            // Find removed APIs. (APIs in browsers before date - 1yr
-            // set minus APIs in version released just before date - 1yr).
-            return Promise.all(promises).then(() => {
-              return browser.interfaces.select({
-                put: function(_, iface) {
+
+            // Helper: Perform SET_MINUS(removedIFaces, browserDAO's ifaces).
+            function removeFromRemoved(browserDAO) {
+              return browserDAO.interfaces.select(this.AnonymousSink.create({
+                sink: {put: function(_, iface) {
                   if (removedIfaces.hasOwnProperty(iface.interfaceKey)) {
                     delete removedIfaces[iface.interfaceKey];
                   }
-                },
-              }).then(() => {
-                // Find the interfaces that still exists in today's
-                // other browsers.
-                promises = [];
-                for (let i = 0; i < currBrowsers.length; i++) {
-                  promises.push(currBrowsers[i].interfaces.select({
-                    put: function(_, iface) {
-                      if (removedIfaces.hasOwnProperty(iface.interfaceKey)) {
-                        removedIfaces[iface.interfaceKey]++;
-                      }
-                    },
-                  }));
-                }
-                return Promise.all(promises).then(() => {
-                  // Find number of APIs still exists in all today's
-                  // other version of browsers.
-                  let numAggressiveRemoval = Object.keys(removedIfaces).filter(
-                      (ifaceKey) => {
-                    return removedIfaces[ifaceKey] === currBrowsers.length;
-                  }).length;
-                  return this.aggressiveRemovalDAO.put(
-                      this.AggressiveRemovalData.create({
-                        browserName: browser.browserName,
-                        browserOneYearAgo: browser,
-                        prevReleaseBrowsers,
-                        currBrowsers,
-                        numAggressiveRemoval,
-                        date,
-                      }));
-                });
+                }},
+              }));
+            }
+            // Find removed APIs: APIs in browsers before date -1yr set-minus
+            // APIs in version released just before date -1yr. Also set-minus
+            // latest version of the same browser to avoid penalizing vendors
+            // that reintroduce an API after premature removal.
+            return Promise.all(promises).then(() => Promise.all([
+              removeFromRemoved.call(this, latestPrevReleaseBrowser),
+              removeFromRemoved.call(this, browser),
+            ])).then(() => {
+              // Find the interfaces that still exists in today's
+              // other browsers.
+              promises = [];
+              for (let i = 0; i < currBrowsers.length; i++) {
+                promises.push(currBrowsers[i].interfaces.select(
+                    this.AnonymousSink.create({
+                      sink: {put: function(_, iface) {
+                        if (removedIfaces.hasOwnProperty(
+                            iface.interfaceKey)) {
+                          removedIfaces[iface.interfaceKey]++;
+                        }
+                      }},
+                    })));
+              }
+              return Promise.all(promises).then(() => {
+                // Find number of APIs still exists in all today's
+                // other version of browsers.
+                let numAggressiveRemoval = Object.keys(removedIfaces).filter(
+                    (ifaceKey) => {
+                      return removedIfaces[ifaceKey] === currBrowsers.length;
+                    }).length;
+                return this.aggressiveRemovalDAO.put(
+                    this.AggressiveRemovalData.create({
+                      browserName: browser.browserName,
+                      browserOneYearAgo: latestPrevReleaseBrowser,
+                      prevReleaseBrowsers,
+                      currBrowsers,
+                      numAggressiveRemoval,
+                      date,
+                    }));
               });
             });
           }));

--- a/lib/confluence/aggressive_removal.es6.js
+++ b/lib/confluence/aggressive_removal.es6.js
@@ -77,9 +77,7 @@ foam.CLASS({
             for (let i = 0; i < prevReleaseBrowsers.length; i++) {
               promises.push(prevReleaseBrowsers[i].interfaces.select(
                   this.AnonymousSink.create({sink: {put: function(_, iface) {
-                    if (!removedIfaces.hasOwnProperty(iface.interfaceKey)) {
                       removedIfaces[iface.interfaceKey] = 0;
-                    }
                   }}})));
             }
 

--- a/lib/confluence/failure_to_ship.es6.js
+++ b/lib/confluence/failure_to_ship.es6.js
@@ -14,13 +14,14 @@ foam.CLASS({
       that available in other browsers for a year but is never available
       in this browser.`,
   requires: [
-    'org.chromium.apis.web.Browser',
-    'org.chromium.apis.web.WebInterface',
-    'org.chromium.apis.web.BrowserWebInterfaceJunction',
-    'org.chromium.apis.web.FailureToShipData',
-    'foam.mlang.ExpressionsSingleton',
+    'foam.dao.AnonymousSink',
     'foam.dao.ArraySink',
     'foam.dao.EasyDAO',
+    'foam.mlang.ExpressionsSingleton',
+    'org.chromium.apis.web.Browser',
+    'org.chromium.apis.web.BrowserWebInterfaceJunction',
+    'org.chromium.apis.web.FailureToShipData',
+    'org.chromium.apis.web.WebInterface',
   ],
   properties: [
     {
@@ -86,22 +87,21 @@ foam.CLASS({
               } else if (result.a[i].browserKey !== browser.browserKey) {
                 prevReleaseBrowsers.push(result.a[i]);
               }
-              promises.push(result.a[i].interfaces.select({
-                put: function(_, iface) {
-                  if (result.a[i].browserName === browser.browserName) {
-                    browserIface[iface.interfaceKey] = true;
-                  } else {
-                    // Interfaces may have names defined in majorIface's
-                    // prototype chain; that's why we don't use
-                    // majorIface[iface.interfaceKey] =
-                    //     (majorIface[iface.interfaceKey] || 0) + 1.
-                    if (!majorIface.hasOwnProperty(iface.interfaceKey)) {
-                      majorIface[iface.interfaceKey] = 0;
+              promises.push(result.a[i].interfaces.select(
+                  this.AnonymousSink.create({sink: {put: function(_, iface) {
+                    if (result.a[i].browserName === browser.browserName) {
+                      browserIface[iface.interfaceKey] = true;
+                    } else {
+                      // Interfaces may have names defined in majorIface's
+                      // prototype chain; that's why we don't use
+                      // majorIface[iface.interfaceKey] =
+                      //     (majorIface[iface.interfaceKey] || 0) + 1.
+                      if (!majorIface.hasOwnProperty(iface.interfaceKey)) {
+                        majorIface[iface.interfaceKey] = 0;
+                      }
+                      majorIface[iface.interfaceKey]++;
                     }
-                    majorIface[iface.interfaceKey]++;
-                  }
-                },
-              }));
+                  }}})));
             }
             return Promise.all(promises).then(() => {
               // Find interfaces that all other vendors' browsers supports

--- a/lib/confluence/metric_computer.es6.js
+++ b/lib/confluence/metric_computer.es6.js
@@ -102,25 +102,27 @@ foam.CLASS({
       },
     },
     {
-      name: 'init',
-      documentation: `The init function computes the Metric Result
-          for each major browsers contained in the given browserApiDAO.`,
+      name: 'run',
+      documentation: `Computes the Metric Result for each major browsers
+          contained in the given browserApiDAO.`,
       code: function() {
-        this.browserDAO.select(
+        return this.browserDAO.select(
             this.mlang.GROUP_BY(this.Browser.BROWSER_NAME, this.mlang.GROUP_BY(
                 this.Browser.OS_NAME,
                 this.mlang.COUNT())))
         .then((groups) => {
           let numVendors = groups.groupKeys.length;
-          this.getOrderedListOfBrowserReleaseDates().then((dates) => {
+          return this.getOrderedListOfBrowserReleaseDates().then((dates) => {
+            let promises = [];
             for (let i = 0; i < dates.length; i++) {
               let date = dates[i];
-              this.getLatestBrowserFromEachVendorAtDate(date)
+              promises.push(this.getLatestBrowserFromEachVendorAtDate(date)
                   .then((browsers) => {
-                    if (browsers.length !== numVendors) return;
-                    this.compute(browsers, date);
-                  });
+                    if (browsers.length === numVendors)
+                      return this.compute(browsers, date);
+                  }));
             }
+            return Promise.all(promises);
           });
         });
       },

--- a/lib/confluence/metric_computer.es6.js
+++ b/lib/confluence/metric_computer.es6.js
@@ -110,21 +110,21 @@ foam.CLASS({
             this.mlang.GROUP_BY(this.Browser.BROWSER_NAME, this.mlang.GROUP_BY(
                 this.Browser.OS_NAME,
                 this.mlang.COUNT())))
-        .then((groups) => {
-          let numVendors = groups.groupKeys.length;
-          return this.getOrderedListOfBrowserReleaseDates().then((dates) => {
-            let promises = [];
-            for (let i = 0; i < dates.length; i++) {
-              let date = dates[i];
-              promises.push(this.getLatestBrowserFromEachVendorAtDate(date)
-                  .then((browsers) => {
-                    if (browsers.length === numVendors)
-                      return this.compute(browsers, date);
-                  }));
-            }
-            return Promise.all(promises);
-          });
-        });
+            .then((groups) => {
+              let numVendors = groups.groupKeys.length;
+              return this.getOrderedListOfBrowserReleaseDates().then((dates) => {
+                let promises = [];
+                for (let i = 0; i < dates.length; i++) {
+                  let date = dates[i];
+                  promises.push(this.getLatestBrowserFromEachVendorAtDate(date)
+                      .then((browsers) => {
+                        if (browsers.length === numVendors)
+                          return this.compute(browsers, date);
+                      }));
+                }
+                return Promise.all(promises);
+              });
+            });
       },
     },
     {

--- a/lib/confluence/vendor_specific.es6.js
+++ b/lib/confluence/vendor_specific.es6.js
@@ -16,13 +16,14 @@ foam.CLASS({
     releases), and have not been visible in any other browser vendor during
     the last year's releases.`,
   requires: [
-    'org.chromium.apis.web.Browser',
-    'org.chromium.apis.web.WebInterface',
-    'org.chromium.apis.web.BrowserWebInterfaceJunction',
-    'org.chromium.apis.web.VendorSpecificData',
-    'foam.mlang.ExpressionsSingleton',
+    'foam.dao.AnonymousSink',
     'foam.dao.ArraySink',
     'foam.dao.EasyDAO',
+    'foam.mlang.ExpressionsSingleton',
+    'org.chromium.apis.web.Browser',
+    'org.chromium.apis.web.BrowserWebInterfaceJunction',
+    'org.chromium.apis.web.VendorSpecificData',
+    'org.chromium.apis.web.WebInterface',
   ],
   properties: [
     {
@@ -87,18 +88,21 @@ foam.CLASS({
                     numPrevReleases++;
                     prevReleaseBrowsers.push(result.a[i]);
                   }
-                  promises.push(result.a[i].interfaces.select({
-                    put: function(_, iface) {
-                      if (result.a[i].browserName === browser.browserName) {
-                        if (!browserIface.hasOwnProperty(iface.interfaceKey)) {
-                          browserIface[iface.interfaceKey] = 0;
-                        }
-                        browserIface[iface.interfaceKey]++;
-                      } else {
-                        allOtherIfaces[iface.interfaceKey] = true;
-                      }
-                    },
-                  }));
+                  promises.push(result.a[i].interfaces.select(
+                      this.AnonymousSink.create({sink: {
+                        put: function(_, iface) {
+                          if (result.a[i].browserName === browser.browserName) {
+                            if (!browserIface.hasOwnProperty(
+                                iface.interfaceKey)) {
+                              browserIface[iface.interfaceKey] = 0;
+                            }
+                            browserIface[iface.interfaceKey]++;
+                          } else {
+                            allOtherIfaces[iface.interfaceKey] = true;
+                          }
+                        },
+                      }})
+                      ));
                 }
                 return Promise.all(promises).then(() => {
                   // Find interfaces that all this browser have shipped and not

--- a/lib/web_apis/api_importer.es6.js
+++ b/lib/web_apis/api_importer.es6.js
@@ -11,6 +11,7 @@ require('./version_history.es6.js');
 foam.CLASS({
   name: 'ApiImporter',
   package: 'org.chromium.apis.web',
+
   documentation: `API Importer is a class that handles importing browserAPIs
     from webCatalog object to browserAPI DAO.`,
   requires: [
@@ -109,29 +110,31 @@ foam.CLASS({
         },
       ],
       code: function(browserName, browserVersion,
-        osName, osVersion, apiCatalog) {
-          let browser = this.Browser.create({
-            browserName,
-            browserVersion,
-            osName,
-            osVersion,
-            releaseDate: this.versionHistory
+                     osName, osVersion, apiCatalog) {
+        let promises = [];
+        let browser = this.Browser.create({
+          browserName,
+          browserVersion,
+          osName,
+          osVersion,
+          releaseDate: this.versionHistory
               .getReleaseDate(browserName, browserVersion),
-          });
-          this.browserDAO.put(browser);
-          let interfaceNames = Object.keys(apiCatalog);
-          for (let i = 0; i < interfaceNames.length; i += 1) {
-            let interfaceName = interfaceNames[i];
-            for (let j = 0; j < apiCatalog[interfaceName].length; j += 1) {
-              let apiName = apiCatalog[interfaceName][j];
-              let webInterface = this.WebInterface.create({
-                interfaceName,
-                apiName,
-              });
-              this.interfaceDAO.put(webInterface);
-              webInterface.browsers.put(browser);
-            }
+        });
+        promises.push(this.browserDAO.put(browser));
+        let interfaceNames = Object.keys(apiCatalog);
+        for (let i = 0; i < interfaceNames.length; i++) {
+          let interfaceName = interfaceNames[i];
+          for (let j = 0; j < apiCatalog[interfaceName].length; j++) {
+            let apiName = apiCatalog[interfaceName][j];
+            let webInterface = this.WebInterface.create({
+              interfaceName,
+              apiName,
+            });
+            promises.push(this.interfaceDAO.put(webInterface));
+            promises.push(webInterface.browsers.put(browser));
           }
+        }
+        return Promise.all(promises);
       },
     },
   ],

--- a/test/any/confluence/aggressive_removal-test.es6.js
+++ b/test/any/confluence/aggressive_removal-test.es6.js
@@ -1,0 +1,747 @@
+// Copyright 2017 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+'use strict';
+
+describe('AggressiveRemoval', function() {
+  let testCtx;
+  beforeEach(function() {
+    foam.CLASS({
+      name: 'Controller',
+      package: 'org.chromium.apis.web.test',
+
+      requires: [
+        'foam.dao.EasyDAO',
+        'org.chromium.apis.web.Browser',
+        'org.chromium.apis.web.WebInterface',
+        'org.chromium.apis.web.BrowserWebInterfaceJunction',
+      ],
+      exports: [
+        'browserDAO',
+        'webInterfaceDAO',
+        'browserWebInterfaceJunctionDAO',
+      ],
+
+      properties: [
+        {
+          class: 'foam.dao.DAOProperty',
+          name: 'browserDAO',
+          factory: function() {
+            return this.EasyDAO.create({
+              name: 'browserDAO',
+              of: this.Browser,
+              daoType: 'ARRAY',
+            });
+          },
+        },
+        {
+          class: 'foam.dao.DAOProperty',
+          name: 'webInterfaceDAO',
+          factory: function() {
+            return this.EasyDAO.create({
+              name: 'webInterfaceDAO',
+              of: this.WebInterface,
+              daoType: 'ARRAY',
+            });
+          },
+        },
+        {
+          class: 'foam.dao.DAOProperty',
+          name: 'browserWebInterfaceJunctionDAO',
+          factory: function() {
+            return this.EasyDAO.create({
+              name: 'browserWebInterfaceJunctionDAO',
+              of: this.BrowserWebInterfaceJunction,
+              daoType: 'ARRAY',
+            });
+          },
+        },
+      ],
+    });
+    testCtx = foam.lookup('org.chromium.apis.web.test.Controller')
+        .create().__subContext__;
+  });
+
+  it('should handle simple case', function(done) {
+    const Browser = testCtx.lookup('org.chromium.apis.web.Browser');
+    const WebInterface = testCtx.lookup('org.chromium.apis.web.WebInterface');
+    const AggressiveRemoval =
+        testCtx.lookup('org.chromium.apis.web.AggressiveRemoval');
+    const browsers = testCtx.browserDAO;
+    let alpha1, alpha2, alpha3, beta, charlie, aggressiveRemoval;
+    // Instantiate browser releases:
+    // Alpha 1, 2, 3: ~1 year apart.
+    // Beta, Charlie: same year as Alpha 3.
+    Promise.all([
+      browsers.put(Browser.create({
+        browserName: 'Alpha',
+        browserVersion: '1',
+        osName: 'Windows',
+        osVersion: '10',
+        releaseDate: '2015-01-01T00:00:00.000Z'
+      }, testCtx)),
+      browsers.put(Browser.create({
+        browserName: 'Alpha',
+        browserVersion: '2',
+        osName: 'Windows',
+        osVersion: '10',
+        releaseDate: '2016-01-02T00:00:00.000Z'
+      }, testCtx)),
+      browsers.put(Browser.create({
+        browserName: 'Alpha',
+        browserVersion: '3',
+        osName: 'Windows',
+        osVersion: '10',
+        releaseDate: '2017-01-03T00:00:00.000Z'
+      }, testCtx)),
+      browsers.put(Browser.create({
+        browserName: 'Beta',
+        browserVersion: '1',
+        osName: 'Windows',
+        osVersion: '10',
+        releaseDate: '2017-01-04T00:00:00.000Z'
+      }, testCtx)),
+      browsers.put(Browser.create({
+        browserName: 'Charlie',
+        browserVersion: '1',
+        osName: 'Windows',
+        osVersion: '10',
+        releaseDate: '2017-01-05T00:00:00.000Z'
+      }, testCtx)),
+    ]).then(function(browsersArray) {
+      alpha1 = browsersArray[0];
+      alpha2 = browsersArray[1];
+      alpha3 = browsersArray[2];
+      beta = browsersArray[3];
+      charlie = browsersArray[4];
+
+      // One API, shipped by Alpha, Beta, and Charlie, removed in Alpha 2,
+      // more than a year after Alpha 3, Beta, and Charlie releases.
+      // That is, API ships in Alpha 1, Beta, and Charlie.
+      const ifaces = testCtx.webInterfaceDAO;
+      const Junction =
+          foam.lookup('org.chromium.apis.web.BrowserWebInterfaceJunction');
+      const junctions = testCtx.browserWebInterfaceJunctionDAO;
+      const iface = WebInterface.create({
+        interfaceName: 'Alpha',
+        apiName: 'removesIn2',
+      }, testCtx);
+      return Promise.all([
+        ifaces.put(iface),
+        junctions.put(Junction.create({
+          id: [alpha1.id, iface.id],
+          sourceId: alpha1.id,
+          targetId: iface.id,
+        })),
+        junctions.put(Junction.create({
+          id: [beta.id, iface.id],
+          sourceId: beta.id,
+          targetId: iface.id,
+        })),
+        junctions.put(Junction.create({
+          id: [charlie.id, iface.id],
+          sourceId: charlie.id,
+          targetId: iface.id,
+        })),
+      ]);
+    }).then(function() {
+      // Setup and run aggressive removal metric calculation.
+      aggressiveRemoval = AggressiveRemoval.create({
+        browserDAO: testCtx.browserDAO,
+        interfaceDAO: testCtx.webInterfaceDAO,
+        browserApiDAO: testCtx.browserWebInterfaceJunctionDAO,
+      }, testCtx);
+      return aggressiveRemoval.run();
+    }).then(function() {
+      return aggressiveRemoval.aggressiveRemovalDAO.select();
+    }).then(function(sink) {
+      var array = sink.a;
+      // One data point satisfies computation constraints:
+      // 1. Computed from date with at least one version from each vendor,
+      // 2. Computed from date with at least two versions >1yr-old from vendor
+      //    whose removals are under analysis.
+      expect(array.length).toBe(1);
+      var ar = array[0];
+      expect(ar.browserName).toBe('Alpha');
+      expect(ar.numAggressiveRemoval).toBe(1);
+      // First date that all vendors have a release: Charlie release date.
+      expect(ar.date).toEqual(charlie.releaseDate);
+      expect(foam.util.equals(ar.browserOneYearAgo, alpha2)).toBe(true);
+      expect(foam.util.equals(ar.prevReleaseBrowsers, [alpha1])).toBe(true);
+      expect(foam.util.equals(ar.currBrowsers.sort(), [beta, charlie].sort()))
+          .toBe(true);
+      done();
+    });
+  });
+
+  it('should not capture removal less than a year old', function(done) {
+    const Browser = testCtx.lookup('org.chromium.apis.web.Browser');
+    const WebInterface = testCtx.lookup('org.chromium.apis.web.WebInterface');
+    const AggressiveRemoval =
+        testCtx.lookup('org.chromium.apis.web.AggressiveRemoval');
+    const browsers = testCtx.browserDAO;
+    let alpha0, alpha1, alpha2, alpha3, beta, charlie, aggressiveRemoval;
+    // Instantiate browser releases:
+    // Alpha 0, 1, 2, 3: ~1 year apart.
+    // Beta, Charlie: same year as Alpha 3.
+    // Here, Alpha 2 released less than a year before Alpha 3, Beta, or Charlie.
+    // Alpha 0 is introduced to hit case where there are two Alpha versions old
+    // enough to compute Alpha's aggressive removals.
+    Promise.all([
+      browsers.put(Browser.create({
+        browserName: 'Alpha',
+        browserVersion: '0',
+        osName: 'Windows',
+        osVersion: '10',
+        releaseDate: '2014-01-01T00:00:00.000Z'
+      }, testCtx)),
+      browsers.put(Browser.create({
+        browserName: 'Alpha',
+        browserVersion: '1',
+        osName: 'Windows',
+        osVersion: '10',
+        releaseDate: '2015-01-01T00:00:00.000Z'
+      }, testCtx)),
+      browsers.put(Browser.create({
+        browserName: 'Alpha',
+        browserVersion: '2',
+        osName: 'Windows',
+        osVersion: '10',
+        releaseDate: '2016-01-06T00:00:00.000Z'
+      }, testCtx)),
+      browsers.put(Browser.create({
+        browserName: 'Alpha',
+        browserVersion: '3',
+        osName: 'Windows',
+        osVersion: '10',
+        releaseDate: '2017-01-03T00:00:00.000Z'
+      }, testCtx)),
+      browsers.put(Browser.create({
+        browserName: 'Beta',
+        browserVersion: '1',
+        osName: 'Windows',
+        osVersion: '10',
+        releaseDate: '2017-01-04T00:00:00.000Z'
+      }, testCtx)),
+      browsers.put(Browser.create({
+        browserName: 'Charlie',
+        browserVersion: '1',
+        osName: 'Windows',
+        osVersion: '10',
+        releaseDate: '2017-01-05T00:00:00.000Z'
+      }, testCtx)),
+    ]).then(function(browsersArray) {
+      alpha0 = browsersArray[0];
+      alpha1 = browsersArray[1];
+      alpha2 = browsersArray[2];
+      alpha3 = browsersArray[3];
+      beta = browsersArray[4];
+      charlie = browsersArray[5];
+
+      // One API, shipped by Alpha, Beta, and Charlie, removed in Alpha 2,
+      // but less than a year after Alpha 3, Beta, and Charlie releases.
+      // That is, API ships in Alpha 0, Alpha 1, Beta, and Charlie.
+      const ifaces = testCtx.webInterfaceDAO;
+      const Junction =
+          foam.lookup('org.chromium.apis.web.BrowserWebInterfaceJunction');
+      const junctions = testCtx.browserWebInterfaceJunctionDAO;
+      const iface = WebInterface.create({
+        interfaceName: 'Alpha',
+        apiName: 'removesIn2',
+      }, testCtx);
+      return Promise.all([
+        ifaces.put(iface),
+        junctions.put(Junction.create({
+          id: [alpha0.id, iface.id],
+          sourceId: alpha0.id,
+          targetId: iface.id,
+        })),
+        junctions.put(Junction.create({
+          id: [alpha1.id, iface.id],
+          sourceId: alpha1.id,
+          targetId: iface.id,
+        })),
+        junctions.put(Junction.create({
+          id: [beta.id, iface.id],
+          sourceId: beta.id,
+          targetId: iface.id,
+        })),
+        junctions.put(Junction.create({
+          id: [charlie.id, iface.id],
+          sourceId: charlie.id,
+          targetId: iface.id,
+        })),
+      ]);
+    }).then(function() {
+      // Setup and run aggressive removal metric calculation.
+      aggressiveRemoval = AggressiveRemoval.create({
+        browserDAO: testCtx.browserDAO,
+        interfaceDAO: testCtx.webInterfaceDAO,
+        browserApiDAO: testCtx.browserWebInterfaceJunctionDAO,
+      }, testCtx);
+      return aggressiveRemoval.run();
+    }).then(function() {
+      return aggressiveRemoval.aggressiveRemovalDAO.select();
+    }).then(function(sink) {
+      var array = sink.a;
+      // One data point satisfies computation constraints:
+      // 1. Computed from date with at least one version from each vendor,
+      // 2. Computed from date with at least two versions >1yr-old from vendor
+      //    whose removals are under analysis.
+      expect(array.length).toBe(1);
+      var ar = array[0];
+      expect(ar.browserName).toBe('Alpha');
+      // Removal in Alpha 2 not counted: it's less than 1yr-old.
+      expect(ar.numAggressiveRemoval).toBe(0);
+      // First date that all vendors have a release: Charlie release date.
+      expect(ar.date).toEqual(charlie.releaseDate);
+      expect(foam.util.equals(ar.browserOneYearAgo, alpha1)).toBe(true);
+      expect(foam.util.equals(ar.prevReleaseBrowsers, [alpha0])).toBe(true);
+      expect(foam.util.equals(ar.currBrowsers.sort(), [beta, charlie].sort()))
+          .toBe(true);
+      done();
+    });
+  });
+
+  it('should capture old removals', function(done) {
+    const Browser = testCtx.lookup('org.chromium.apis.web.Browser');
+    const WebInterface = testCtx.lookup('org.chromium.apis.web.WebInterface');
+    const AggressiveRemoval =
+        testCtx.lookup('org.chromium.apis.web.AggressiveRemoval');
+    const browsers = testCtx.browserDAO;
+    let alpha0, alpha1, alpha2, alpha3, beta, charlie, aggressiveRemoval;
+    // Instantiate browser releases:
+    // Alpha 0, 1, 2, 3: ~1 year apart.
+    // Beta, Charlie: same year as Alpha 3.
+    // Alpha 0 is introduced to get two removals from different years.
+    Promise.all([
+      browsers.put(Browser.create({
+        browserName: 'Alpha',
+        browserVersion: '0',
+        osName: 'Windows',
+        osVersion: '10',
+        releaseDate: '2014-01-01T00:00:00.000Z'
+      }, testCtx)),
+      browsers.put(Browser.create({
+        browserName: 'Alpha',
+        browserVersion: '1',
+        osName: 'Windows',
+        osVersion: '10',
+        releaseDate: '2015-01-02T00:00:00.000Z'
+      }, testCtx)),
+      browsers.put(Browser.create({
+        browserName: 'Alpha',
+        browserVersion: '2',
+        osName: 'Windows',
+        osVersion: '10',
+        releaseDate: '2016-01-03T00:00:00.000Z'
+      }, testCtx)),
+      browsers.put(Browser.create({
+        browserName: 'Alpha',
+        browserVersion: '3',
+        osName: 'Windows',
+        osVersion: '10',
+        releaseDate: '2017-01-04T00:00:00.000Z'
+      }, testCtx)),
+      browsers.put(Browser.create({
+        browserName: 'Beta',
+        browserVersion: '1',
+        osName: 'Windows',
+        osVersion: '10',
+        releaseDate: '2017-01-05T00:00:00.000Z'
+      }, testCtx)),
+      browsers.put(Browser.create({
+        browserName: 'Charlie',
+        browserVersion: '1',
+        osName: 'Windows',
+        osVersion: '10',
+        releaseDate: '2017-01-06T00:00:00.000Z'
+      }, testCtx)),
+    ]).then(function(browsersArray) {
+      alpha0 = browsersArray[0];
+      alpha1 = browsersArray[1];
+      alpha2 = browsersArray[2];
+      alpha3 = browsersArray[3];
+      beta = browsersArray[4];
+      charlie = browsersArray[5];
+
+      // Two APIs, shipped by Alpha, Beta, and Charlie, one removed in Alpha
+      // 1, another removed in Alpha 2, both removed over a year before Alpha
+      // 3, Beta, and Charlie releases.
+      const ifaces = testCtx.webInterfaceDAO;
+      const Junction =
+          foam.lookup('org.chromium.apis.web.BrowserWebInterfaceJunction');
+      const junctions = testCtx.browserWebInterfaceJunctionDAO;
+      const iface1 = WebInterface.create({
+        interfaceName: 'Alpha',
+        apiName: 'removesIn1',
+      }, testCtx);
+      const iface2 = WebInterface.create({
+        interfaceName: 'Alpha',
+        apiName: 'removesIn2',
+      }, testCtx);
+      return Promise.all([
+        ifaces.put(iface1),
+        ifaces.put(iface2),
+
+        // iface1 removed in Alpha 1.
+        junctions.put(Junction.create({
+          id: [alpha0.id, iface1.id],
+          sourceId: alpha0.id,
+          targetId: iface1.id,
+        })),
+        junctions.put(Junction.create({
+          id: [beta.id, iface1.id],
+          sourceId: beta.id,
+          targetId: iface1.id,
+        })),
+        junctions.put(Junction.create({
+          id: [charlie.id, iface1.id],
+          sourceId: charlie.id,
+          targetId: iface1.id,
+        })),
+
+        // iface2 removed in Alpha 2.
+        junctions.put(Junction.create({
+          id: [alpha0.id, iface2.id],
+          sourceId: alpha0.id,
+          targetId: iface2.id,
+        })),
+        junctions.put(Junction.create({
+          id: [alpha1.id, iface2.id],
+          sourceId: alpha1.id,
+          targetId: iface2.id,
+        })),
+        junctions.put(Junction.create({
+          id: [beta.id, iface2.id],
+          sourceId: beta.id,
+          targetId: iface2.id,
+        })),
+        junctions.put(Junction.create({
+          id: [charlie.id, iface2.id],
+          sourceId: charlie.id,
+          targetId: iface2.id,
+        })),
+      ]);
+    }).then(function() {
+      // Setup and run aggressive removal metric calculation.
+      aggressiveRemoval = AggressiveRemoval.create({
+        browserDAO: testCtx.browserDAO,
+        interfaceDAO: testCtx.webInterfaceDAO,
+        browserApiDAO: testCtx.browserWebInterfaceJunctionDAO,
+      }, testCtx);
+      return aggressiveRemoval.run();
+    }).then(function() {
+      return aggressiveRemoval.aggressiveRemovalDAO.select();
+    }).then(function(sink) {
+      var array = sink.a;
+      // One data point satisfies computation constraints:
+      // 1. Computed from date with at least one version from each vendor,
+      // 2. Computed from date with at least two versions >1yr-old from vendor
+      //    whose removals are under analysis.
+      expect(array.length).toBe(1);
+      var ar = array[0];
+      expect(ar.browserName).toBe('Alpha');
+      // Both removals counted.
+      expect(ar.numAggressiveRemoval).toBe(2);
+      // First date that all vendors have a release: Charlie release date.
+      expect(ar.date).toEqual(charlie.releaseDate);
+      expect(foam.util.equals(ar.browserOneYearAgo, alpha2)).toBe(true);
+      expect(foam.util.equals(ar.prevReleaseBrowsers.sort(),
+                              [alpha0, alpha1].sort()))
+                                  .toBe(true);
+      expect(foam.util.equals(ar.currBrowsers.sort(), [beta, charlie].sort()))
+          .toBe(true);
+      done();
+    });
+  });
+
+  it('should capture accumulate old removals', function(done) {
+    const Browser = testCtx.lookup('org.chromium.apis.web.Browser');
+    const WebInterface = testCtx.lookup('org.chromium.apis.web.WebInterface');
+    const AggressiveRemoval =
+        testCtx.lookup('org.chromium.apis.web.AggressiveRemoval');
+    const browsers = testCtx.browserDAO;
+    let alpha0, alpha1, alpha2, alpha3, beta, charlie, aggressiveRemoval;
+    // Instantiate browser releases:
+    // Alpha 0, 1, 2, 3: ~1 year apart.
+    // Beta, Charlie: same year as Alpha 2.
+    // Alpha 0 is introduced to get two removals from different years.
+    Promise.all([
+      browsers.put(Browser.create({
+        browserName: 'Alpha',
+        browserVersion: '0',
+        osName: 'Windows',
+        osVersion: '10',
+        releaseDate: '2014-01-01T00:00:00.000Z'
+      }, testCtx)),
+      browsers.put(Browser.create({
+        browserName: 'Alpha',
+        browserVersion: '1',
+        osName: 'Windows',
+        osVersion: '10',
+        releaseDate: '2015-01-02T00:00:00.000Z'
+      }, testCtx)),
+      browsers.put(Browser.create({
+        browserName: 'Alpha',
+        browserVersion: '2',
+        osName: 'Windows',
+        osVersion: '10',
+        releaseDate: '2016-01-03T00:00:00.000Z'
+      }, testCtx)),
+      browsers.put(Browser.create({
+        browserName: 'Beta',
+        browserVersion: '1',
+        osName: 'Windows',
+        osVersion: '10',
+        releaseDate: '2016-01-04T00:00:00.000Z'
+      }, testCtx)),
+      browsers.put(Browser.create({
+        browserName: 'Charlie',
+        browserVersion: '1',
+        osName: 'Windows',
+        osVersion: '10',
+        releaseDate: '2016-01-05T00:00:00.000Z'
+      }, testCtx)),
+      browsers.put(Browser.create({
+        browserName: 'Alpha',
+        browserVersion: '3',
+        osName: 'Windows',
+        osVersion: '10',
+        releaseDate: '2017-01-06T00:00:00.000Z'
+      }, testCtx)),
+    ]).then(function(browsersArray) {
+      alpha0 = browsersArray[0];
+      alpha1 = browsersArray[1];
+      alpha2 = browsersArray[2];
+      beta = browsersArray[3];
+      charlie = browsersArray[4];
+      alpha3 = browsersArray[5];
+
+      // Two APIs, shipped by Alpha, Beta, and Charlie, one removed in Alpha
+      // 1, another removed in Alpha 2, one removed over a year before Beta,
+      // and Charlie releases, the other removed over a year before Alpha 3
+      // release.
+      const ifaces = testCtx.webInterfaceDAO;
+      const Junction =
+          foam.lookup('org.chromium.apis.web.BrowserWebInterfaceJunction');
+      const junctions = testCtx.browserWebInterfaceJunctionDAO;
+      const iface1 = WebInterface.create({
+        interfaceName: 'Alpha',
+        apiName: 'removesIn1',
+      }, testCtx);
+      const iface2 = WebInterface.create({
+        interfaceName: 'Alpha',
+        apiName: 'removesIn2',
+      }, testCtx);
+      return Promise.all([
+        ifaces.put(iface1),
+        ifaces.put(iface2),
+
+        // iface1 removed in Alpha 1.
+        junctions.put(Junction.create({
+          id: [alpha0.id, iface1.id],
+          sourceId: alpha0.id,
+          targetId: iface1.id,
+        })),
+        junctions.put(Junction.create({
+          id: [beta.id, iface1.id],
+          sourceId: beta.id,
+          targetId: iface1.id,
+        })),
+        junctions.put(Junction.create({
+          id: [charlie.id, iface1.id],
+          sourceId: charlie.id,
+          targetId: iface1.id,
+        })),
+
+        // iface2 removed in Alpha 2.
+        junctions.put(Junction.create({
+          id: [alpha0.id, iface2.id],
+          sourceId: alpha0.id,
+          targetId: iface2.id,
+        })),
+        junctions.put(Junction.create({
+          id: [alpha1.id, iface2.id],
+          sourceId: alpha1.id,
+          targetId: iface2.id,
+        })),
+        junctions.put(Junction.create({
+          id: [beta.id, iface2.id],
+          sourceId: beta.id,
+          targetId: iface2.id,
+        })),
+        junctions.put(Junction.create({
+          id: [charlie.id, iface2.id],
+          sourceId: charlie.id,
+          targetId: iface2.id,
+        })),
+      ]);
+    }).then(function() {
+      // Setup and run aggressive removal metric calculation.
+      aggressiveRemoval = AggressiveRemoval.create({
+        browserDAO: testCtx.browserDAO,
+        interfaceDAO: testCtx.webInterfaceDAO,
+        browserApiDAO: testCtx.browserWebInterfaceJunctionDAO,
+      }, testCtx);
+      return aggressiveRemoval.run();
+    }).then(function() {
+      return aggressiveRemoval.aggressiveRemovalDAO.select();
+    }).then(function(sink) {
+      var array = sink.a;
+      // Two data points satisfies computation constraints:
+      // 1. Computed from date with at least one version from each vendor,
+      // 2. Computed from date with at least two versions >1yr-old from vendor
+      //    whose removals are under analysis.
+      expect(array.length).toBe(2);
+
+      // First point: Removal from Alpha 1 counted at time of Charlie release.
+      var ar1 = array[0];
+      expect(ar1.browserName).toBe('Alpha');
+      expect(ar1.numAggressiveRemoval).toBe(1);
+      // First date that all vendors have a release: Charlie release date.
+      expect(ar1.date).toEqual(charlie.releaseDate);
+      expect(foam.util.equals(ar1.browserOneYearAgo, alpha1)).toBe(true);
+      expect(foam.util.equals(ar1.prevReleaseBrowsers.sort(), [alpha0].sort()))
+          .toBe(true);
+      expect(foam.util.equals(ar1.currBrowsers.sort(), [beta, charlie].sort()))
+          .toBe(true);
+      done();
+
+      // Second point: Removals from Alpha 1 and Alpha 2 counted at time of
+      // Alpha 3 release.
+      var ar2 = array[1];
+      expect(ar2.browserName).toBe('Alpha');
+      // Both removals counted.
+      expect(ar2.numAggressiveRemoval).toBe(2);
+      // First date that all vendors have a release: Charlie release date.
+      expect(ar2.date).toEqual(alpha3.releaseDate);
+      expect(foam.util.equals(ar2.browserOneYearAgo, alpha2)).toBe(true);
+      expect(foam.util.equals(ar2.prevReleaseBrowsers.sort(),
+                              [alpha0, alpha1].sort()))
+                                  .toBe(true);
+      expect(foam.util.equals(ar2.currBrowsers.sort(), [beta, charlie].sort()))
+          .toBe(true);
+      done();
+    });
+  });
+
+  it('should not count APIs that are reintroduced', function(done) {
+    const Browser = testCtx.lookup('org.chromium.apis.web.Browser');
+    const WebInterface = testCtx.lookup('org.chromium.apis.web.WebInterface');
+    const AggressiveRemoval =
+        testCtx.lookup('org.chromium.apis.web.AggressiveRemoval');
+    const browsers = testCtx.browserDAO;
+    let alpha1, alpha2, alpha3, beta, charlie, aggressiveRemoval;
+    // Instantiate browser releases:
+    // Alpha 1, 2, 3: ~1 year apart.
+    // Beta, Charlie: same year as Alpha 3.
+    Promise.all([
+      browsers.put(Browser.create({
+        browserName: 'Alpha',
+        browserVersion: '1',
+        osName: 'Windows',
+        osVersion: '10',
+        releaseDate: '2015-01-01T00:00:00.000Z'
+      }, testCtx)),
+      browsers.put(Browser.create({
+        browserName: 'Alpha',
+        browserVersion: '2',
+        osName: 'Windows',
+        osVersion: '10',
+        releaseDate: '2016-01-02T00:00:00.000Z'
+      }, testCtx)),
+      browsers.put(Browser.create({
+        browserName: 'Alpha',
+        browserVersion: '3',
+        osName: 'Windows',
+        osVersion: '10',
+        releaseDate: '2017-01-03T00:00:00.000Z'
+      }, testCtx)),
+      browsers.put(Browser.create({
+        browserName: 'Beta',
+        browserVersion: '1',
+        osName: 'Windows',
+        osVersion: '10',
+        releaseDate: '2017-01-04T00:00:00.000Z'
+      }, testCtx)),
+      browsers.put(Browser.create({
+        browserName: 'Charlie',
+        browserVersion: '1',
+        osName: 'Windows',
+        osVersion: '10',
+        releaseDate: '2017-01-05T00:00:00.000Z'
+      }, testCtx)),
+    ]).then(function(browsersArray) {
+      alpha1 = browsersArray[0];
+      alpha2 = browsersArray[1];
+      alpha3 = browsersArray[2];
+      beta = browsersArray[3];
+      charlie = browsersArray[4];
+
+      // One API, shipped by Alpha, Beta, and Charlie, removed in Alpha 2,
+      // more than a year after Alpha 3, Beta, and Charlie releases. However,
+      // Alpha re-introduced API in version 3.
+      // That is, API ships in Alpha 1, Alpha 3, Beta, and Charlie.
+      const ifaces = testCtx.webInterfaceDAO;
+      const Junction =
+          foam.lookup('org.chromium.apis.web.BrowserWebInterfaceJunction');
+      const junctions = testCtx.browserWebInterfaceJunctionDAO;
+      const iface = WebInterface.create({
+        interfaceName: 'Alpha',
+        apiName: 'removesIn2',
+      }, testCtx);
+      return Promise.all([
+        ifaces.put(iface),
+        junctions.put(Junction.create({
+          id: [alpha1.id, iface.id],
+          sourceId: alpha1.id,
+          targetId: iface.id,
+        })),
+        junctions.put(Junction.create({
+          id: [alpha3.id, iface.id],
+          sourceId: alpha3.id,
+          targetId: iface.id,
+        })),
+        junctions.put(Junction.create({
+          id: [beta.id, iface.id],
+          sourceId: beta.id,
+          targetId: iface.id,
+        })),
+        junctions.put(Junction.create({
+          id: [charlie.id, iface.id],
+          sourceId: charlie.id,
+          targetId: iface.id,
+        })),
+      ]);
+    }).then(function() {
+      // Setup and run aggressive removal metric calculation.
+      aggressiveRemoval = AggressiveRemoval.create({
+        browserDAO: testCtx.browserDAO,
+        interfaceDAO: testCtx.webInterfaceDAO,
+        browserApiDAO: testCtx.browserWebInterfaceJunctionDAO,
+      }, testCtx);
+      return aggressiveRemoval.run();
+    }).then(function() {
+      return aggressiveRemoval.aggressiveRemovalDAO.select();
+    }).then(function(sink) {
+      var array = sink.a;
+      // One data point satisfies computation constraints:
+      // 1. Computed from date with at least one version from each vendor,
+      // 2. Computed from date with at least two versions >1yr-old from vendor
+      //    whose removals are under analysis.
+      expect(array.length).toBe(1);
+      var ar = array[0];
+      expect(ar.browserName).toBe('Alpha');
+      // Removal in Alpha 2 not counted: API is later reintroduced.
+      expect(ar.numAggressiveRemoval).toBe(0);
+      // First date that all vendors have a release: Charlie release date.
+      expect(ar.date).toEqual(charlie.releaseDate);
+      expect(foam.util.equals(ar.browserOneYearAgo, alpha2)).toBe(true);
+      expect(foam.util.equals(ar.prevReleaseBrowsers, [alpha1])).toBe(true);
+      expect(foam.util.equals(ar.currBrowsers.sort(), [beta, charlie].sort()))
+          .toBe(true);
+      done();
+    });
+  });
+});

--- a/test/any/web_apis/api_importer-test.es6.js
+++ b/test/any/web_apis/api_importer-test.es6.js
@@ -17,11 +17,11 @@ describe('ApiImporter', function() {
 
   let apiImporter;
   let mlang;
-  beforeEach(function() {
+  beforeEach(function(done) {
     apiImporter = org.chromium.apis.web.ApiImporter.create();
     mlang = foam.mlang.ExpressionsSingleton.create();
     apiImporter.import('Chrome', '56.0.2924.87',
-                       'OSX', '10.12.2', webCatalog);
+                       'OSX', '10.12.2', webCatalog).then(done);
   });
 
   it('correctly imports browserWebInterfaceJunction to DAO', function(done) {


### PR DESCRIPTION
In addition to test code, this PR contains a fix for the aggressive removal algorithm, and models sinks passed to `someDAO.select()` to make sure the underlying implementation does choke on a missing sink method.