### PR TITLE
Implement UNION set operation as UnionDAO

### DIFF
--- a/lib/confluence/set_ops.es6.js
+++ b/lib/confluence/set_ops.es6.js
@@ -187,3 +187,113 @@ foam.CLASS({
     },
   ],
 });
+
+foam.CLASS({
+  package: 'org.chromium.dao',
+  name: 'UnionDAO',
+  extends: 'foam.dao.AbstractDAO',
+  implements: ['foam.mlang.Expressions'],
+
+  documentation: 'Read-only DAO that captures the union of two delegate DAOs.',
+
+  classes: [
+    {
+      name: 'NoEOFSink',
+      extends: 'foam.dao.ProxySink',
+
+      methods: [function eof() {}],
+    },
+  ],
+
+  properties: [
+    {
+      class: 'foam.dao.DAOProperty',
+      name: 'primary',
+      required: true,
+    },
+    {
+      class: 'foam.dao.DAOProperty',
+      name: 'secondary',
+      required: true,
+    },
+    {
+      name: 'of',
+      factory: function() {
+        return this.primary.of;
+      },
+    },
+  ],
+
+  methods: [
+    function put(o) {
+      throw new Error('Attempt to put() to read-only UnionDAO');
+    },
+    function remove(o) {
+      throw new Error('Attempt to remove() from read-only UnionDAO');
+    },
+    function removeAll(o) {
+      throw new Error('Attempt to removeAll() from read-only UnionDAO');
+    },
+    function find(key) {
+      return new Promise((resolve, reject) => {
+        var data = {done: false, resolve: resolve, reject: reject};
+        var onFind = this.onFind.bind(this, data);
+        var onError = this.onFindError.bind(this, data);
+        this.primary.find(key).then(onFind, onError);
+        this.secondary.find(key).then(onFind, onError);
+      });
+    },
+    function select(sink, skip, limit, order, predicate) {
+      if (skip || limit || order || predicate)
+        throw new Error('UnionDAO does not support skip/limit/order/predicate');
+
+      return new Promise((resolve, reject) => {
+        var data = {doneCount: 0, errorCount: 0, sink: sink, resolve: resolve, reject: reject};
+        var onSelect = this.onSelect.bind(this, data);
+        var onError = this.onSelectError.bind(this, data);
+
+        // Select primary -> "sink"-with-no-eof() callback.
+        this.primary.select(this.NoEOFSink.create({delegate: sink}))
+            .then(onSelect, onError);
+        // Select secondary \ primary -> "sink"-with-no-eof() callback.
+        this.secondary.select(
+            this.SET_MINUS(this.primary, this.NoEOFSink.create({
+              delegate: sink,
+            })))
+                .then(onSelect, onError);
+      });
+    },
+  ],
+
+  listeners: [
+    function onFind(data, o) {
+      if (data.done) return;
+      data.done = true;
+      data.resolve(o);
+    },
+    function onFindError(data, error) {
+      if (data.done) return;
+      data.done = true;
+      data.reject(error);
+    },
+    function onSelect(data, o) {
+      // Halt select() control flow after first error.
+      if (data.errorCount !== 0) return;
+
+      // Do not eof() + resolve() until both select() control flows complete.
+      data.doneCount++;
+      if (data.doneCount !== 2) return;
+
+      // Ensure exactly one eof() call after all inner select()s complete.
+      data.sink.eof();
+      data.resolve(data.sink);
+    },
+    function onSelectError(data, error) {
+      // Halt select() control flow after first error.
+      if (data.errorCount !== 0) return;
+
+      data.errorCount++;
+      data.reject(error);
+    },
+  ],
+});

--- a/lib/confluence/set_ops.es6.js
+++ b/lib/confluence/set_ops.es6.js
@@ -232,7 +232,7 @@ foam.CLASS({
             this.SET_MINUS(this.primary, this.NoEOFSink.create({
               delegate: sink,
             })))
-                .then(onSelect, onError);
+            .then(onSelect, onError);
       });
     },
     function listen(sink, skip, limit, order, predicate) {
@@ -242,7 +242,7 @@ foam.CLASS({
       // Listen to primary.
       this.primary.listen(sink);
       // Listen to secondary \ primary.
-      this.primary.listen(this.SET_MINUS(this.primary, sink));
+      this.secondary.listen(this.SET_MINUS(this.primary, sink));
     },
   ],
 

--- a/lib/confluence/set_ops.es6.js
+++ b/lib/confluence/set_ops.es6.js
@@ -158,43 +158,14 @@ foam.CLASS({
 });
 
 foam.CLASS({
-  package: 'org.chromium.mlang',
-  name: 'Expressions',
-  refines: 'foam.mlang.Expressions',
-
-  documentation: 'Adds set operations to foam.mlang.Expressions',
-
-  requires: [
-    'org.chromium.mlang.sink.AsyncSink',
-    'org.chromium.mlang.sink.IntersectDecider',
-    'org.chromium.mlang.sink.SetMinusDecider',
-  ],
-
-  methods: [
-    function SET_MINUS(dao, sink) {
-      return this.AsyncSink.create({
-        decider: this.SetMinusDecider.create(),
-        delegate: sink,
-        secondary: dao,
-      });
-    },
-    function INTERSECT(dao, sink) {
-      return this.AsyncSink.create({
-        decider: this.IntersectDecider.create(),
-        delegate: sink,
-        secondary: dao,
-      });
-    },
-  ],
-});
-
-foam.CLASS({
   package: 'org.chromium.dao',
   name: 'UnionDAO',
   extends: 'foam.dao.AbstractDAO',
   implements: ['foam.mlang.Expressions'],
 
   documentation: 'Read-only DAO that captures the union of two delegate DAOs.',
+
+  requires: ['foam.dao.ArraySink'],
 
   classes: [
     {
@@ -243,7 +214,8 @@ foam.CLASS({
         this.secondary.find(key).then(onFind, onError);
       });
     },
-    function select(sink, skip, limit, order, predicate) {
+    function select(opt_sink, skip, limit, order, predicate) {
+      var sink = opt_sink || this.ArraySink.create();
       if (skip || limit || order || predicate)
         throw new Error('UnionDAO does not support skip/limit/order/predicate');
 
@@ -262,6 +234,15 @@ foam.CLASS({
             })))
                 .then(onSelect, onError);
       });
+    },
+    function listen(sink, skip, limit, order, predicate) {
+      if (skip || limit || order || predicate)
+        throw new Error('UnionDAO does not support skip/limit/order/predicate');
+
+      // Listen to primary.
+      this.primary.listen(sink);
+      // Listen to secondary \ primary.
+      this.primary.listen(this.SET_MINUS(this.primary, sink));
     },
   ],
 
@@ -294,6 +275,44 @@ foam.CLASS({
 
       data.errorCount++;
       data.reject(error);
+    },
+  ],
+});
+
+foam.CLASS({
+  package: 'org.chromium.mlang',
+  name: 'Expressions',
+  refines: 'foam.mlang.Expressions',
+
+  documentation: 'Adds set operations to foam.mlang.Expressions',
+
+  requires: [
+    'org.chromium.dao.UnionDAO',
+    'org.chromium.mlang.sink.AsyncSink',
+    'org.chromium.mlang.sink.IntersectDecider',
+    'org.chromium.mlang.sink.SetMinusDecider',
+  ],
+
+  methods: [
+    function SET_MINUS(dao, sink) {
+      return this.AsyncSink.create({
+        decider: this.SetMinusDecider.create(),
+        delegate: sink,
+        secondary: dao,
+      });
+    },
+    function INTERSECT(dao, sink) {
+      return this.AsyncSink.create({
+        decider: this.IntersectDecider.create(),
+        delegate: sink,
+        secondary: dao,
+      });
+    },
+    function UNION(primary, secondary) {
+      return this.UnionDAO.create({
+        primary: primary,
+        secondary: secondary,
+      });
     },
   ],
 });


### PR DESCRIPTION
Chose to do this one as a DAO instead of a sink because the secondary introduces new data that are not backed by the primary. I.e., it _feels wrong_ to implement something that supports:

```js
foo.select(UNION(bar))
```

where the data `put()` to the sink would include items that are not contained in `foo`.