### PR TITLE
UnionDAO: union-of-none and resolve(null) fixes

### DIFF
--- a/lib/confluence/set_ops.es6.js
+++ b/lib/confluence/set_ops.es6.js
@@ -295,6 +295,7 @@ foam.CLASS({
 
   requires: [
     'foam.dao.NullDAO',
+    'foam.dao.ReadOnlyDAO',
     'org.chromium.dao.UnionDAO',
     'org.chromium.mlang.sink.AsyncSink',
     'org.chromium.mlang.sink.IntersectDecider',
@@ -318,7 +319,9 @@ foam.CLASS({
           secondary: next,
         });
       }
-      return next || this.NullDAO.create();
+      return next || this.ReadOnlyDAO.create({
+        delegate: this.NullDAO.create(),
+      });
     },
 
     function cascadeSink_(DeciderClass, array, sink) {

--- a/lib/confluence/set_ops.es6.js
+++ b/lib/confluence/set_ops.es6.js
@@ -257,7 +257,7 @@ foam.CLASS({
       // Resolve with value of "o" if null previously found, or o is non-null.
       var shouldResolve = data.found === null || o !== null;
       data.found = o;
-      if (shouldResolve) data.resolve(data.found = o);
+      if (shouldResolve) data.resolve(data.found);
     },
     function onFindError(data, error) {
       if (data.errored === true || data.found !== null) return;

--- a/lib/confluence/set_ops.es6.js
+++ b/lib/confluence/set_ops.es6.js
@@ -201,7 +201,7 @@ foam.CLASS({
     function find(key) {
       return new Promise((resolve, reject) => {
         var data = {
-          found: null,
+          found: undefined,
           errored: false,
           resolve: resolve,
           reject: reject,
@@ -252,9 +252,12 @@ foam.CLASS({
 
   listeners: [
     function onFind(data, o) {
-      if (data.errored === true || data.found !== null) return;
+      // Return if already reject()ed or resolve()d promise.
+      if (data.errored === true || data.found) return;
+      // Resolve with value of "o" if null previously found, or o is non-null.
+      var shouldResolve = data.found === null || o !== null;
       data.found = o;
-      if (o !== null) data.resolve(data.found);
+      if (shouldResolve) data.resolve(data.found = o);
     },
     function onFindError(data, error) {
       if (data.errored === true || data.found !== null) return;
@@ -291,6 +294,7 @@ foam.CLASS({
   documentation: 'Adds set operations to foam.mlang.Expressions',
 
   requires: [
+    'foam.dao.NullDAO',
     'org.chromium.dao.UnionDAO',
     'org.chromium.mlang.sink.AsyncSink',
     'org.chromium.mlang.sink.IntersectDecider',
@@ -314,7 +318,7 @@ foam.CLASS({
           secondary: next,
         });
       }
-      return next;
+      return next || this.NullDAO.create();
     },
 
     function cascadeSink_(DeciderClass, array, sink) {

--- a/test/any/confluence/set_ops-test.es6.js
+++ b/test/any/confluence/set_ops-test.es6.js
@@ -522,5 +522,17 @@ describe('Set ops', () => {
       });
     });
 
+    it('should resolve null on find() with inconsistent callback timing', done => {
+      var aDAO = EvilDAO.create({of: Num, delegate: MDAO.create({of: Num})});
+      var bDAO = EvilDAO.create({of: Num, delegate: MDAO.create({of: Num})});
+      var abDAO = E.UNION(aDAO, bDAO);
+
+      Promise.all([
+        abDAO.find(0).then(found => expect(found).toBeNull()),
+        abDAO.find(1).then(found => expect(found).toBeNull()),
+        abDAO.find(2).then(found => expect(found).toBeNull()),
+        abDAO.find(3).then(found => expect(found).toBeNull()),
+      ]).then(done, done.fail);
+    });
   });
 });


### PR DESCRIPTION
- The union of no DAOs is the empty read-only `NullDAO`;
- Fix NullDAO bug (and add test): When primary and secondary both `resolve(null)`, the `UnionDAO` was not calling `resolve(null)`.