### PR TITLE
Switch to web socket-based StreamingClientDAOs

### DIFF
--- a/lib/client/api_service.es6.js
+++ b/lib/client/api_service.es6.js
@@ -15,15 +15,9 @@ require('../web_apis/web_interface.es6.js');
 // this into a FOAM class when porting to FOAM classloader.
 angular.module('confluence').service('api', ['$window', function($window) {
   const ORIGIN = $window.location.origin;
-  const RELEASE_API_URL = ORIGIN + '/release-apis';
-  const RELEASE_URL = ORIGIN + '/releases';
-  const WEB_INTERFACE_URL = ORIGIN + '/web-interfaces';
-  const API_VELOCITY_URL = ORIGIN + '/api-velocity';
-  const FAILURE_TO_SHIP_URL = ORIGIN + '/failure-to-ship';
-  const BROWSER_SPECIFIC_URL = ORIGIN + '/browser-specific';
-  const AGGRESSIVE_REMOVAL_URL = ORIGIN + '/aggressive-removal';
 
-  const ctx = foam.box.Context.create();
+  let container = org.chromium.apis.web.DAOContainer.create(
+      null, foam.box.Context.create());
   // Names must match those registered in in server box context.
   function getClientDAO(name, cls) {
     return foam.dao.StreamingClientDAO.create({
@@ -34,9 +28,9 @@ angular.module('confluence').service('api', ['$window', function($window) {
           // TODO(markdittmer): Explicitly select webSocketService port.
           // (Current default: 4000.)
           uri: 'ws://0.0.0.0:4000',
-        }, ctx),
-      }, ctx),
-    }, ctx);
+        }, container),
+      }, container),
+    }, container);
   }
 
   const Release = org.chromium.apis.web.Release;
@@ -45,23 +39,24 @@ angular.module('confluence').service('api', ['$window', function($window) {
       org.chromium.apis.web.ReleaseWebInterfaceJunction;
 
   let releaseDAO = foam.dao.EasyDAO.create({
-    name: 'releaseDAO',
+    name: container.RELEASE_NAME,
     of: Release,
     daoType: 'MDAO',
   });
   let webInterfaceDAO = foam.dao.EasyDAO.create({
-    name: 'webInterfaceDAO',
+    name: container.WEB_INTERFACE_NAME,
     of: WebInterface,
     daoType: 'MDAO',
   });
   let releaseWebInterfaceJunctionDAO = getClientDAO(
-      'releaseWebInterfaceJunctionDAO', ReleaseWebInterfaceJunction);
+      container.RELEASE_WEB_INTERFACE_JUNCTION_NAME,
+      ReleaseWebInterfaceJunction);
   let promises = [];
-  promises.push(getClientDAO('releaseDAO', Release)
+  promises.push(getClientDAO(container.RELEASE_NAME, Release)
       .select(foam.dao.AnonymousSink.create({
         sink: {put: release => releaseDAO.put(release)},
       })));
-  promises.push(getClientDAO('webInterfaceDAO', WebInterface)
+  promises.push(getClientDAO(container.WEB_INTERFACE_NAME, WebInterface)
       .select(foam.dao.AnonymousSink.create({
         sink: {put: webInterface => webInterfaceDAO.put(webInterface)},
       })));
@@ -79,15 +74,17 @@ angular.module('confluence').service('api', ['$window', function($window) {
     releaseWebInterfaceJunctionDAO,
   }));
 
-  const ApiVelocityData = foam.lookup('org.chromium.apis.web.ApiVelocityData');
-  const BrowserMetricData =
-      foam.lookup('org.chromium.apis.web.BrowserMetricData');
-  let apiVelocityDAO = getClientDAO('apiVelocityDAO', ApiVelocityData);
-  let failureToShipDAO = getClientDAO('failureToShipDAO', BrowserMetricData);
+  const ApiVelocityData = org.chromium.apis.web.ApiVelocityData;
+  const BrowserMetricData = org.chromium.apis.web.BrowserMetricData;
+  let apiVelocityDAO = getClientDAO(
+      container.API_VELOCITY_NAME,
+      ApiVelocityData);
+  let failureToShipDAO =
+      getClientDAO(container.FAILURE_TO_SHIP_NAME, BrowserMetricData);
   let browserSpecificDAO =
-      getClientDAO('browserSpecificDAO', BrowserMetricData);
+      getClientDAO(container.BROWSER_SPECIFIC_NAME, BrowserMetricData);
   let aggressiveRemovalDAO =
-      getClientDAO('aggressiveRemovalDAO', BrowserMetricData);
+      getClientDAO(container.AGGRESSIVE_REMOVAL_NAME, BrowserMetricData);
   let apiConfluence = org.chromium.apis.web.ApiConfluence.create({
     apiVelocityDAO,
     failureToShipDAO,

--- a/lib/client/api_service.es6.js
+++ b/lib/client/api_service.es6.js
@@ -76,9 +76,8 @@ angular.module('confluence').service('api', ['$window', function($window) {
 
   const ApiVelocityData = org.chromium.apis.web.ApiVelocityData;
   const BrowserMetricData = org.chromium.apis.web.BrowserMetricData;
-  let apiVelocityDAO = getClientDAO(
-      container.API_VELOCITY_NAME,
-      ApiVelocityData);
+  let apiVelocityDAO =
+      getClientDAO(container.API_VELOCITY_NAME, ApiVelocityData);
   let failureToShipDAO =
       getClientDAO(container.FAILURE_TO_SHIP_NAME, BrowserMetricData);
   let browserSpecificDAO =

--- a/lib/client/api_service.es6.js
+++ b/lib/client/api_service.es6.js
@@ -23,33 +23,48 @@ angular.module('confluence').service('api', ['$window', function($window) {
   const BROWSER_SPECIFIC_URL = ORIGIN + '/browser-specific';
   const AGGRESSIVE_REMOVAL_URL = ORIGIN + '/aggressive-removal';
 
+  const ctx = foam.box.Context.create();
+  // Names must match those registered in in server box context.
+  function getClientDAO(name, cls) {
+    return foam.dao.StreamingClientDAO.create({
+      of: cls,
+      delegate: foam.box.SubBox.create({
+        name: name,
+        delegate: foam.box.WebSocketBox.create({
+          // TODO(markdittmer): Explicitly select webSocketService port.
+          // (Current default: 4000.)
+          uri: 'ws://0.0.0.0:4000',
+        }, ctx),
+      }, ctx),
+    }, ctx);
+  }
+
+  const Release = org.chromium.apis.web.Release;
+  const WebInterface = org.chromium.apis.web.WebInterface;
+  const ReleaseWebInterfaceJunction =
+      org.chromium.apis.web.ReleaseWebInterfaceJunction;
+
   let releaseDAO = foam.dao.EasyDAO.create({
     name: 'releaseDAO',
-    of: org.chromium.apis.web.Release,
+    of: Release,
     daoType: 'MDAO',
   });
   let webInterfaceDAO = foam.dao.EasyDAO.create({
     name: 'webInterfaceDAO',
-    of: org.chromium.apis.web.WebInterface,
+    of: WebInterface,
     daoType: 'MDAO',
   });
-  let releaseWebInterfaceJunctionDAO = foam.dao.RestDAO.create({
-    baseURL: RELEASE_API_URL,
-    of: org.chromium.apis.web.ReleaseWebInterfaceJunction,
-  });
+  let releaseWebInterfaceJunctionDAO = getClientDAO(
+      'releaseWebInterfaceJunctionDAO', ReleaseWebInterfaceJunction);
   let promises = [];
-  promises.push(foam.dao.RestDAO.create({
-    baseURL: RELEASE_URL,
-    of: org.chromium.apis.web.Release,
-  }).select(foam.dao.AnonymousSink.create({
-    sink: {put: release => releaseDAO.put(release)},
-  })));
-  promises.push(foam.dao.RestDAO.create({
-    baseURL: WEB_INTERFACE_URL,
-    of: org.chromium.apis.web.WebInterface,
-  }).select(foam.dao.AnonymousSink.create({
-    sink: {put: webInterface => webInterfaceDAO.put(webInterface)},
-  })));
+  promises.push(getClientDAO('releaseDAO', Release)
+      .select(foam.dao.AnonymousSink.create({
+        sink: {put: release => releaseDAO.put(release)},
+      })));
+  promises.push(getClientDAO('webInterfaceDAO', WebInterface)
+      .select(foam.dao.AnonymousSink.create({
+        sink: {put: webInterface => webInterfaceDAO.put(webInterface)},
+      })));
   let apiMatrix = org.chromium.apis.web.ApiMatrix.create({
     releaseWebInterfaceJunctionDAO,
     releaseDAO,
@@ -60,22 +75,19 @@ angular.module('confluence').service('api', ['$window', function($window) {
   // DAOs on Relationships.
   foam.__context__.createSubContext({
     releaseDAO,
-    webInterfaceDAO: webInterfaceDAO,
-    releaseWebInterfaceJunctionDAO: releaseWebInterfaceJunctionDAO,
+    webInterfaceDAO,
+    releaseWebInterfaceJunctionDAO,
   }));
 
-  let apiVelocityDAO = foam.dao.RestDAO.create({
-    baseURL: API_VELOCITY_URL,
-  });
-  let failureToShipDAO = foam.dao.RestDAO.create({
-    baseURL: FAILURE_TO_SHIP_URL,
-  });
-  let browserSpecificDAO = foam.dao.RestDAO.create({
-    baseURL: BROWSER_SPECIFIC_URL,
-  });
-  let aggressiveRemovalDAO = foam.dao.RestDAO.create({
-    baseURL: AGGRESSIVE_REMOVAL_URL,
-  });
+  const ApiVelocityData = foam.lookup('org.chromium.apis.web.ApiVelocityData');
+  const BrowserMetricData =
+      foam.lookup('org.chromium.apis.web.BrowserMetricData');
+  let apiVelocityDAO = getClientDAO('apiVelocityDAO', ApiVelocityData);
+  let failureToShipDAO = getClientDAO('failureToShipDAO', BrowserMetricData);
+  let browserSpecificDAO =
+      getClientDAO('browserSpecificDAO', BrowserMetricData);
+  let aggressiveRemovalDAO =
+      getClientDAO('aggressiveRemovalDAO', BrowserMetricData);
   let apiConfluence = org.chromium.apis.web.ApiConfluence.create({
     apiVelocityDAO,
     failureToShipDAO,

--- a/lib/controller/default.es6.js
+++ b/lib/controller/default.es6.js
@@ -1,0 +1,11 @@
+// Copyright 2017 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+'use strict';
+
+require('angular');
+
+// Provide controller for default view that will depend on API service.
+angular.module('confluence')
+  .controller('defaultController',
+    ['$scope', 'api', function($scope, api) {}]);

--- a/lib/controller/default.es6.js
+++ b/lib/controller/default.es6.js
@@ -7,5 +7,5 @@ require('angular');
 
 // Provide controller for default view that will depend on API service.
 angular.module('confluence')
-  .controller('defaultController',
-    ['$scope', 'api', function($scope, api) {}]);
+    .controller('defaultController',
+                ['$scope', 'api', function($scope, api) {}]);

--- a/lib/dao_container.es6.js
+++ b/lib/dao_container.es6.js
@@ -23,6 +23,16 @@ foam.CLASS({
     'webInterfaceDAO',
   ],
 
+  constants: {
+    RELEASE_NAME: 'releaseDAO',
+    WEB_INTERFACE_NAME: 'webInterfaceDAO',
+    RELEASE_WEB_INTERFACE_JUNCTION_NAME: 'releaseWebInterfaceJunctionDAO',
+    API_VELOCITY_NAME: 'apiVelocityDAO',
+    FAILURE_TO_SHIP_NAME: 'failureToShipDAO',
+    BROWSER_SPECIFIC_NAME: 'browserSpecificDAO',
+    AGGRESSIVE_REMOVAL_NAME: 'aggressiveRemovalDAO',
+  },
+
   properties: [
     {
       class: 'foam.dao.DAOProperty',

--- a/lib/dao_container.es6.js
+++ b/lib/dao_container.es6.js
@@ -23,6 +23,9 @@ foam.CLASS({
     'webInterfaceDAO',
   ],
 
+  // Names applied to DAOs on both ends of WebSocket. These names are
+  // consolidated here to ensure that they match on the web client and front end
+  // server.
   constants: {
     RELEASE_NAME: 'releaseDAO',
     WEB_INTERFACE_NAME: 'webInterfaceDAO',

--- a/lib/datastore/datastore_container.es6.js
+++ b/lib/datastore/datastore_container.es6.js
@@ -21,7 +21,7 @@ foam.CLASS({
   requires: [
     'com.google.cloud.datastore.BatchMutationDatastoreDAO',
     'com.google.net.node.Google2LOAuthAgent',
-    'foam.nanos.log.ConsoleLogger',
+    'foam.log.ConsoleLogger',
     'org.chromium.apis.web.ApiVelocityData',
     'org.chromium.apis.web.BrowserMetricData',
     'org.chromium.apis.web.Release',
@@ -115,7 +115,7 @@ foam.CLASS({
     },
     {
       name: 'ctx',
-      documentation: 'Context in which components are created',
+      documentation: 'Context in which components are created.',
       factory: function() {
         // Cascade exports from logger and authAgent into context.
         var ctx = this.__subContext__.createSubContext(this.logger);
@@ -128,7 +128,7 @@ foam.CLASS({
     },
     {
       class: 'FObjectProperty',
-      of: 'foam.nanos.log.Logger',
+      of: 'foam.log.Logger',
       name: 'logger',
       factory: function() { return this.ConsoleLogger.create(); },
     },
@@ -149,13 +149,6 @@ foam.CLASS({
             'https://www.googleapis.com/auth/cloud-platform',
             'https://www.googleapis.com/auth/datastore'
           ],
-        });
-      },
-    },
-    {
-      name: 'daoContainer',
-      factory: function() {
-        return this.DAOContainer.create({
         });
       },
     },

--- a/main/app.es6.js
+++ b/main/app.es6.js
@@ -19,11 +19,13 @@ let app = angular.module('confluence', ['ui.router']);
 require('../lib/client/api_service.es6.js');
 require('../lib/controller/api_catalog.es6.js');
 require('../lib/controller/api_confluence.es6.js');
+require('../lib/controller/default.es6.js');
 
 app.config(function($stateProvider, $urlRouterProvider) {
   $stateProvider.state({
     name: 'home',
     url: '/',
+    controller: 'defaultController',
     template: require('../static/view/home.html'),
   });
 
@@ -48,4 +50,3 @@ app.config(function($stateProvider, $urlRouterProvider) {
 
   $urlRouterProvider.otherwise('/');
 });
-

--- a/main/datastore_metric_upload.es6.js
+++ b/main/datastore_metric_upload.es6.js
@@ -23,7 +23,7 @@ const credentials = JSON.parse(fs.readFileSync(
     path.resolve(__dirname, '../.local/credentials.json')));
 
 const logger = global.logger =
-    foam.lookup('foam.nanos.log.ConsoleLogger').create();
+    foam.lookup('foam.log.ConsoleLogger').create();
 
 const datastoreCtx = global.datastoreCtx =
     foam.lookup('org.chromium.apis.web.DatastoreContainer').create({

--- a/main/datastore_update.es6.js
+++ b/main/datastore_update.es6.js
@@ -51,7 +51,7 @@ const localCtx = foam.__context__.createSubContext({
 });
 const localImporter = global.localImporter =
     foam.lookup('org.chromium.apis.web.ObjectGraphImporter').create({
-      objectGraphPath: path.resolve(__dirname, '../data/og/tmp'),
+      objectGraphPath: path.resolve(__dirname, '../data/og'),
     }, localCtx);
 
 const E = foam.lookup('foam.mlang.ExpressionsSingleton').create();
@@ -69,16 +69,13 @@ const putMissing = global.putMissing = function(local, remote) {
 };
 
 const verify = global.verify = function(local, remote) {
-  return Promise.all([
-    local.select(E.COUNT()),
-    remote.select(E.COUNT()),
-  ]).then(function(sinks) {
+  return Promise.all([local, remote]).then(function(sinks) {
     if (sinks[0].value !== sinks[1].value) {
       logger.error('Counts are different (' + local.of.id + '): ' +
           sinks[0].value + ', ' + sinks[1].value);
       return putMissing(local, remote).then(() => sinks);
     } else {
-      logger.info('Counts match: ' + sinks[0].value + ' (' + local.of.id + ')');
+      logger.info('Counts match (' + local.of.id + ')');
       return sinks;
     }
   });

--- a/main/datastore_update.es6.js
+++ b/main/datastore_update.es6.js
@@ -26,7 +26,7 @@ const credentials = JSON.parse(fs.readFileSync(
     path.resolve(__dirname, '../.local/credentials.json')));
 
 const logger = global.logger =
-    foam.lookup('foam.nanos.log.ConsoleLogger').create();
+    foam.lookup('foam.log.ConsoleLogger').create();
 
 const datastoreCtx = global.datastoreCtx =
     foam.lookup('org.chromium.apis.web.DatastoreContainer').create({
@@ -51,7 +51,7 @@ const localCtx = foam.__context__.createSubContext({
 });
 const localImporter = global.localImporter =
     foam.lookup('org.chromium.apis.web.ObjectGraphImporter').create({
-      objectGraphPath: path.resolve(__dirname, '../data/og'),
+      objectGraphPath: path.resolve(__dirname, '../data/og/tmp'),
     }, localCtx);
 
 const E = foam.lookup('foam.mlang.ExpressionsSingleton').create();
@@ -69,13 +69,16 @@ const putMissing = global.putMissing = function(local, remote) {
 };
 
 const verify = global.verify = function(local, remote) {
-  return Promise.all([local, remote]).then(function(sinks) {
+  return Promise.all([
+    local.select(E.COUNT()),
+    remote.select(E.COUNT()),
+  ]).then(function(sinks) {
     if (sinks[0].value !== sinks[1].value) {
       logger.error('Counts are different (' + local.of.id + '): ' +
           sinks[0].value + ', ' + sinks[1].value);
       return putMissing(local, remote).then(() => sinks);
     } else {
-      logger.info('Counts match (' + local.of.id + ')');
+      logger.info('Counts match: ' + sinks[0].value + ' (' + local.of.id + ')');
       return sinks;
     }
   });

--- a/main/serve.js
+++ b/main/serve.js
@@ -47,16 +47,16 @@ server.exportDirectory('/', `${__dirname}/../static/bundle`);
 // TODO(markdittmer): Can we count on DAO implementations to have a .name
 // property? That would be better than using the key on the context.
 const SkeletonBox = foam.lookup('foam.box.SkeletonBox');
-function registerDAO(name, opt_dao) {
-  var dao = ctx[name] || opt_dao;
+function registerDAO(name, dao) {
   foam.assert(dao, 'Broken use of helper: registerDAO()');
   ctx.registry.register(name, null, SkeletonBox.create({data: dao}, ctx));
 }
 
-registerDAO(daoContainer.RELEASE_NAME);
-registerDAO(daoContainer.WEB_INTERFACE_NAME);
-registerDAO(daoContainer.RELEASE_WEB_INTERFACE_JUNCTION_NAME);
-registerDAO(daoContainer.API_VELOCITY_NAME);
+registerDAO(daoContainer.RELEASE_NAME, ctx.releaseDAO);
+registerDAO(daoContainer.WEB_INTERFACE_NAME, ctx.webInterfaceDAO);
+registerDAO(daoContainer.RELEASE_WEB_INTERFACE_JUNCTION_NAME,
+            ctx.releaseWebInterfaceJunctionDAO);
+registerDAO(daoContainer.API_VELOCITY_NAME, ctx.apiVelocityDAO);
 
 const E = foam.lookup('foam.mlang.ExpressionsSingleton').create();
 const EQ = E.EQ.bind(E);

--- a/main/serve.js
+++ b/main/serve.js
@@ -8,6 +8,8 @@ const path = require('path');
 
 global.FOAM_FLAGS = {gcloud: true};
 require('foam2');
+require('../node_modules/foam2/src/foam/nanos/nanos.js');
+
 require('../lib/confluence/aggressive_removal.es6.js');
 require('../lib/confluence/api_velocity.es6.js');
 require('../lib/confluence/browser_specific.es6.js');
@@ -29,30 +31,51 @@ const ctx = foam.lookup('org.chromium.apis.web.DatastoreContainer').create({
   gcloudAuthPrivateKey: credentials.private_key,
   gcloudProjectId: credentials.project_id,
   logger: logger,
-}).ctx;
+}).ctx.createSubContext(foam.lookup('foam.box.Context').create());
 
 server.exportFile('/', `${__dirname}/../static/index.html`);
+server.exportDirectory('/images', `${__dirname}/../static/images`);
+server.exportDirectory('/', `${__dirname}/../static/bundle`);
 
-server.exportDAO(ctx.releaseDAO, '/releases');
-server.exportDAO(ctx.webInterfaceDAO, '/web-interfaces');
-server.exportDAO(ctx.releaseWebInterfaceJunctionDAO, '/release-apis');
+// TODO(markdittmer): Unify this script by adding support for box-registered
+// DAOs to foam.net.node.Server.
 
-server.exportDAO(ctx.apiVelocityDAO, '/api-velocity');
+// Register DAOs in box context.
+//
+// TODO(markdittmer): Can we count on DAO implementations to have a .name
+// property? That would be better than using the key on the context.
+const SkeletonBox = foam.lookup('foam.box.SkeletonBox');
+function registerDAO(name, opt_dao) {
+  var dao = ctx[name] || opt_dao;
+  foam.assert(dao, 'Broken use of helper: registerDAO()');
+  ctx.registry.register(name, null, SkeletonBox.create({data: dao}, ctx));
+}
+
+registerDAO('releaseDAO');
+registerDAO('webInterfaceDAO');
+registerDAO('releaseWebInterfaceJunctionDAO');
+registerDAO('apiVelocityDAO');
 
 const E = foam.lookup('foam.mlang.ExpressionsSingleton').create();
 const EQ = E.EQ.bind(E);
 const Type = foam.lookup('org.chromium.apis.web.BrowserMetricDataType');
 const TYPE = foam.lookup('org.chromium.apis.web.BrowserMetricData').TYPE;
 
-server.exportDAO(ctx.browserMetricsDAO.where(EQ(TYPE, Type.FAILURE_TO_SHIP)),
-                 '/failure-to-ship');
-server.exportDAO(ctx.browserMetricsDAO.where(EQ(TYPE, Type.BROWSER_SPECIFIC)),
-                 '/browser-specific');
-server.exportDAO(ctx.browserMetricsDAO.where(EQ(TYPE, Type.AGGRESSIVE_REMOVAL)),
-                 '/aggressive-removal');
+registerDAO(
+    'failureToShipDAO',
+    ctx.browserMetricsDAO.where(EQ(TYPE, Type.FAILURE_TO_SHIP)));
+registerDAO(
+    'browserSpecificDAO',
+    ctx.browserMetricsDAO.where(EQ(TYPE, Type.BROWSER_SPECIFIC)));
+registerDAO(
+    'aggressiveRemovalDAO',
+    ctx.browserMetricsDAO.where(EQ(TYPE, Type.AGGRESSIVE_REMOVAL)));
 
-server.exportDirectory('/images', `${__dirname}/../static/images`);
-
-server.exportDirectory('/', `${__dirname}/../static/bundle`);
+// TODO(markdittmer): Explicitly select webSocketService port.
+// (Current default: 4000.)
+//
+// Start service by accessing lazily constructed property.
+ctx.webSocketService;
+console.log(` :: Serving web sockets from ${ctx.webSocketService.port}`);
 
 server.start();

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "angular": "^1.6.3",
     "angular-ui-router": "^0.4.2",
     "d3": "^4.7.4",
-    "foam2": "git://github.com/foam-framework/foam2.git#new-box",
+    "foam2": "git://github.com/foam-framework/foam2.git",
     "jquery": "^3.2.1",
     "materialize-css": "^0.98.1",
     "object-graph-js": "git://github.com/mdittmer/object-graph-js.git"

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "angular": "^1.6.3",
     "angular-ui-router": "^0.4.2",
     "d3": "^4.7.4",
-    "foam2": "git://github.com/foam-framework/foam2.git#beta-1",
+    "foam2": "git://github.com/foam-framework/foam2.git#new-box",
     "jquery": "^3.2.1",
     "materialize-css": "^0.98.1",
     "object-graph-js": "git://github.com/mdittmer/object-graph-js.git"

--- a/test/any/files-helper.js
+++ b/test/any/files-helper.js
@@ -22,6 +22,7 @@ function requireBrowserCode() {
   require('../../lib/component/catalog_table.es6.js');
   require('../../lib/controller/api_catalog.es6.js');
   require('../../lib/controller/api_confluence.es6.js');
+  require('../../lib/controller/default.es6.js');
 }
 
 function requireNodeCode() {

--- a/test/node/dataQuality-integration.es6.js
+++ b/test/node/dataQuality-integration.es6.js
@@ -44,7 +44,7 @@ describeLocal('data quality', function() {
           .then(function(release) { chrome = release; }),
       ctx.releaseDAO.find('Firefox_52.0_Windows_10.0')
           .then(function(release) { firefox = release; }),
-      ctx.releaseDAO.find('Safari_602.4.8_OSX_10.12.3')
+      ctx.releaseDAO.find('Safari_603.2.4_OSX_10.12.5')
           .then(function(release) { safari = release; }),
       ctx.releaseDAO.find('Edge_14.14393_Windows_10.0')
           .then(function(release) { edge = release; }),


### PR DESCRIPTION
This is towards performance improvements for "cold boot" of web UI.

The plan is, roughly:

1. Use DAOs that can stream individual entities;
2. Use a worker to populate IndexedDB in the background
3. Update Angular components make more targeted queries (for "current page") against caching DAO