### PR TITLE
Fix datastore query structure (and destructuring)

### DIFF
--- a/lib/client/api_matrix.es6.js
+++ b/lib/client/api_matrix.es6.js
@@ -101,29 +101,27 @@ foam.CLASS({
             .select(this.AnonymousSink.create({
               sink: {
                 put: junction => {
-                  var apiKeys = junction.targetId.split('#');
-                  foam.assert(apiKeys.length === 2,
-                              `Expected API key of the form:
-                                  Iface#propOrMethod`);
-                  const k0 = apiKeys[0];
-                  const k1 = apiKeys[1];
-                  const k2 = junction.sourceId;
-                  // Function and Object's built-in methods can be
-                  // interface name or API name.
-                  // So matrix[k0] is not sufficient to check if
-                  // k0 exits in matrix, use hasOwnProperty instead.
-                  if (!matrix.hasOwnProperty(k0)) {
-                    matrix[k0] = {};
-                  }
-                  // "hasOwnProperty" could also be a apiName,
-                  // thus use Object.prototype.hasOwnProperty
-                  // to ensure we invoke the right function.
-                  if (!Object.prototype.hasOwnProperty.call(matrix[k0], k1)) {
-                    matrix[k0][k1] = {};
-                  }
-                  matrix[k0][k1][k2] = true;
-                }
-              }
+                  this.webInterfaceDAO.find(junction.targetId).then(iface => {
+                    const k0 = iface.interfaceName;
+                    const k1 = iface.apiName;
+                    const k2 = junction.sourceId;
+                    // Function and Object's built-in methods can be
+                    // interface name or API name.
+                    // So matrix[k0] is not sufficient to check if
+                    // k0 exits in matrix, use hasOwnProperty instead.
+                    if (!matrix.hasOwnProperty(k0)) {
+                      matrix[k0] = {};
+                    }
+                    // "hasOwnProperty" could also be a apiName,
+                    // thus use Object.prototype.hasOwnProperty
+                    // to ensure we invoke the right function.
+                    if (!Object.prototype.hasOwnProperty.call(matrix[k0], k1)) {
+                      matrix[k0][k1] = {};
+                    }
+                    matrix[k0][k1][k2] = true;
+                  });
+                },
+              },
             })).then(() => this.filterMatrix_(matrix, options));
       },
     },

--- a/lib/client/api_matrix.es6.js
+++ b/lib/client/api_matrix.es6.js
@@ -86,18 +86,20 @@ foam.CLASS({
             This structure simplifies for displaying a nested table.`,
       },
       code: function(releaseKeys, options) {
-        options = options || {};
-        let matrix = {};
+        return this.verifyReleaseKeys_(releaseKeys).then(() => {
+          options = options || {};
+          let matrix = {};
 
-        let query = this.IN(this.ReleaseWebInterfaceJunction.SOURCE_ID, releaseKeys);
-        if (options.searchKey) {
-          query = this.AND(
-              query,
-              this.CONTAINS_IC(this.ReleaseWebInterfaceJunction.TARGET_ID,
-                               options.seachKey));
-        }
+          let query = this.IN(this.ReleaseWebInterfaceJunction.SOURCE_ID,
+                              releaseKeys);
+          if (options.searchKey) {
+            query = this.AND(
+                query,
+                this.CONTAINS_IC(this.ReleaseWebInterfaceJunction.TARGET_ID,
+                                 options.seachKey));
+          }
 
-        return this.releaseWebInterfaceJunctionDAO.where(query)
+          return this.releaseWebInterfaceJunctionDAO.where(query)
             .select(this.AnonymousSink.create({
               sink: {
                 put: junction => {
@@ -123,6 +125,7 @@ foam.CLASS({
                 },
               },
             })).then(() => this.filterMatrix_(matrix, options));
+        });
       },
     },
     {
@@ -356,6 +359,30 @@ foam.CLASS({
             }
             return result;
           });
+      },
+    },
+    {
+      name: 'verifyReleaseKeys_',
+      documentation: 'Confirm that input releaseKeys exist in releaseDAO.',
+      args: [
+        {
+          name: 'releaseKeys',
+          typeName: 'Array',
+          documentation: 'Primary keys expected to appear in releaseDAO.',
+        }
+      ],
+      returns: {
+        typeName: 'Promise',
+        documentation: `A promise that resolves iff all input releaseKeys exist
+            in releaseDAO, otherwise rejects.`
+      },
+
+      code: function(releaseKeys) {
+        return Promise.all(releaseKeys.map((releaseId) => this.releaseDAO
+            .find(releaseId).then((release) => {
+              if (release === null)
+                throw new Error(`${releaseId} does not exist.`);
+            })));
       },
     },
   ],

--- a/lib/client/api_matrix.es6.js
+++ b/lib/client/api_matrix.es6.js
@@ -18,6 +18,7 @@ foam.CLASS({
   requires: [
     'foam.dao.AnonymousSink',
     'foam.dao.ArraySink',
+    'org.chromium.apis.web.ReleaseWebInterfaceJunction',
     'org.chromium.apis.web.WebInterface',
   ],
   imports: ['releaseDAO', 'releaseWebInterfaceJunctionDAO'],
@@ -87,24 +88,26 @@ foam.CLASS({
       code: function(releaseKeys, options) {
         options = options || {};
         let matrix = {};
-        let query = this.TRUE;
+
+        let query = this.IN(this.ReleaseWebInterfaceJunction.SOURCE_ID, releaseKeys);
         if (options.searchKey) {
-          query = this.AND(query, this.CONTAINS_IC(
-            this.WebInterface.INTERFACE_KEY, options.searchKey));
+          query = this.AND(
+              query,
+              this.CONTAINS_IC(this.ReleaseWebInterfaceJunction.TARGET_ID,
+                               options.seachKey));
         }
-        return Promise.all(releaseKeys.map(
-          (releaseId) => this.releaseDAO.find(releaseId).then((release) => {
-            // Reject if this release does not exit in database.
-            if (release === null) {
-              return Promise.reject(Error(`${releaseId} does not exist.`));
-            }
-            // TODO(markdittmer): ContextualizingDAO should take care of this.
-            return release.cls_.create(release, this.__subContext__)
-              .interfaces.dao.where(query).select(this.AnonymousSink.create({
-                sink: {put: iface => {
-                  let k0 = iface.interfaceName;
-                  let k1 = iface.apiName;
-                  let k2 = releaseId;
+
+        return this.releaseWebInterfaceJunctionDAO.where(query)
+            .select(this.AnonymousSink.create({
+              sink: {
+                put: junction => {
+                  var apiKeys = junction.targetId.split('#');
+                  foam.assert(apiKeys.length === 2,
+                              `Expected API key of the form:
+                                  Iface#propOrMethod`);
+                  const k0 = apiKeys[0];
+                  const k1 = apiKeys[1];
+                  const k2 = junction.sourceId;
                   // Function and Object's built-in methods can be
                   // interface name or API name.
                   // So matrix[k0] is not sufficient to check if
@@ -115,15 +118,13 @@ foam.CLASS({
                   // "hasOwnProperty" could also be a apiName,
                   // thus use Object.prototype.hasOwnProperty
                   // to ensure we invoke the right function.
-                  if (!Object.prototype.hasOwnProperty
-                      .call(matrix[k0], k1)) {
+                  if (!Object.prototype.hasOwnProperty.call(matrix[k0], k1)) {
                     matrix[k0][k1] = {};
                   }
                   matrix[k0][k1][k2] = true;
-                }},
-              }));
-            })
-        )).then(() => this.filterMatrix_(matrix, options));
+                }
+              }
+            })).then(() => this.filterMatrix_(matrix, options));
       },
     },
     {

--- a/lib/client/api_matrix.es6.js
+++ b/lib/client/api_matrix.es6.js
@@ -21,7 +21,7 @@ foam.CLASS({
     'org.chromium.apis.web.ReleaseWebInterfaceJunction',
     'org.chromium.apis.web.WebInterface',
   ],
-  imports: ['releaseDAO', 'releaseWebInterfaceJunctionDAO'],
+  imports: ['releaseDAO', 'releaseWebInterfaceJunctionDAO', 'webInterfaceDAO'],
 
   methods: [
     {
@@ -378,8 +378,8 @@ foam.CLASS({
       },
 
       code: function(releaseKeys) {
-        return Promise.all(releaseKeys.map((releaseId) => this.releaseDAO
-            .find(releaseId).then((release) => {
+        return Promise.all(releaseKeys.map(
+            (releaseId) => this.releaseDAO.find(releaseId).then((release) => {
               if (release === null)
                 throw new Error(`${releaseId} does not exist.`);
             })));

--- a/lib/datastore/datastore_container.es6.js
+++ b/lib/datastore/datastore_container.es6.js
@@ -21,6 +21,7 @@ foam.CLASS({
   requires: [
     'com.google.cloud.datastore.BatchMutationDatastoreDAO',
     'com.google.net.node.Google2LOAuthAgent',
+    'foam.dao.NoDisjunctionDAO',
     'foam.log.ConsoleLogger',
     'org.chromium.apis.web.ApiVelocityData',
     'org.chromium.apis.web.BrowserMetricData',
@@ -155,42 +156,42 @@ foam.CLASS({
     {
       name: 'releaseDAO',
       factory: function() {
-        return this.BatchMutationDatastoreDAO.create({
-          of: this.Release,
-        }, this.ctx);
+        return this.getDAO(this.Release);
       },
     },
     {
       name: 'webInterfaceDAO',
       factory: function() {
-        return this.BatchMutationDatastoreDAO.create({
-          of: this.WebInterface,
-        }, this.ctx);
+        return this.getDAO(this.WebInterface);
       },
     },
     {
       name: 'releaseWebInterfaceJunctionDAO',
       factory: function() {
-        return this.BatchMutationDatastoreDAO.create({
-          of: this.ReleaseWebInterfaceJunction,
-        }, this.ctx);
+        return this.getDAO(this.ReleaseWebInterfaceJunction);
       },
     },
     {
       name: 'browserMetricsDAO',
       factory: function() {
-        return this.BatchMutationDatastoreDAO.create({
-          of: this.BrowserMetricData,
-        }, this.ctx);
+        return this.getDAO(this.BrowserMetricData);
       },
     },
     {
       name: 'apiVelocityDAO',
       factory: function() {
-        return this.BatchMutationDatastoreDAO.create({
-          of: this.ApiVelocityData,
-        }, this.ctx);
+        return this.getDAO(this.ApiVelocityData);
       },
     },
+  ],
+
+  methods: [
+    function getDAO(cls) {
+      return this.NoDisjunctionDAO.create({
+        delegate: this.BatchMutationDatastoreDAO.create({
+          of: cls,
+        }, this.ctx),
+      }, this.ctx);
+    }
   ],
 });


### PR DESCRIPTION
Issue APIMatrix queries directly over relases IDs to avoid join query with
huge IN(AnArrayProperty, <way-too-many-values>). Support modest collection of
values on IN() clause with NoDisjunctionDAO wrapping DatastoreDAO.