### PR TITLE
Fix a few bugs in Datastore import logic

### DIFF
--- a/lib/dao_container.es6.js
+++ b/lib/dao_container.es6.js
@@ -74,11 +74,4 @@ foam.CLASS({
       final: true,
     },
   ],
-
-  methods: [
-    function init() {
-      this.validate();
-      this.SUPER();
-    },
-  ],
 });

--- a/lib/web_catalog/api_extractor.es6.js
+++ b/lib/web_catalog/api_extractor.es6.js
@@ -43,6 +43,16 @@ foam.CLASS({
           'toString',
           // Constructors have prototype but are not interfaces.
           'constructor',
+        ];
+      },
+    },
+    {
+      name: 'blacklistInterfaces',
+      documentation: `Blacklisted interfaces that may be visited in case they
+          used for post-processing, but will not be stored.`,
+      class: 'StringArray',
+      factory: function() {
+        return [
           // Stated at https://bugzilla.mozilla.org/show_bug.cgi?id=1290786#c6,
           // CSS2Properties are known bugs for some versions in Firefox.
           // We probably want to exclude them.
@@ -117,7 +127,7 @@ foam.CLASS({
 
           // Remove processors:
           this.RemoveInterfacesProcessor.create({
-            interfaceNames: this.blacklistProperties,
+            interfaceNames: this.blacklistInterfaces,
           }),
 
           // Add processors:
@@ -292,7 +302,7 @@ foam.CLASS({
           typeName: 'ObjectGraph',
         },
       ],
-      code: function getFunctionBlacklist(og) {
+      code: function(og) {
         this.builtInFunctionProperties = ['prototype'];
         this.functionId = og.lookup('Function', this.rootId);
         this.functionProtoId = og.lookup('prototype', this.functionId);

--- a/lib/web_catalog/object_graph_importer.es6.js
+++ b/lib/web_catalog/object_graph_importer.es6.js
@@ -33,16 +33,8 @@ foam.CLASS({
 
   properties: [
     {
-      name: 'apiExtractor',
-      documentation: `Extracts interface catalog from object
-          graph object.`,
-      factory: function() {
-        return this.ApiExtractor.create();
-      },
-    },
-    {
       name: 'apiImporter',
-      documentation: 'Imports interface catalog to DAO with rateLimiter.',
+      documentation: 'Imports interface catalog to DAO.',
       factory: function() { return this.ApiImporter.create(); },
     },
     {
@@ -107,7 +99,7 @@ foam.CLASS({
             let osVersion = releaseInfo[4];
             promises.push(this.apiImporter.import(
                 bName, bVersion, osName, osVersion,
-                this.apiExtractor.extractWebCatalog(
+                this.ApiExtractor.create().extractWebCatalog(
                     objectGraph.fromJSON(JSON.parse(fs.readFileSync(
                         filePath))))));
           }

--- a/main/datastore_update.es6.js
+++ b/main/datastore_update.es6.js
@@ -268,7 +268,7 @@ function importData(importDAO, cacheDAO, syncDAO) {
   }
 
   return updateData(importDAO, cacheDAO, syncDAO).then(function() {
-    return syncDAO.synced;
+    return syncDAO.sync();
   }).then(function() {
     logger.info(`Imported ${importDAO.of.id} to Datastore`);
   });


### PR DESCRIPTION
- Collection of interfaces to blacklist is not the same as collection of properties to blacklist

- A fresh `ApiExtractor` is needed for each run because it is stateful on `Object` and `Function` interface members

- Ensure that a `sync()` run occurs when attempting to `updateData` (not that a previous sync run has ever completed, as `synced` Promise would guarantee)