### PR TITLE
Apply foam.web.URLState tracking atop AngularJS UI-Router tracking

### DIFF
--- a/lib/client/api_service.es6.js
+++ b/lib/client/api_service.es6.js
@@ -55,19 +55,12 @@ angular.module('confluence').service('api', function() {
     }, ctx),
   }, ctx);
   const urlState = foam.web.URLState.create(null, ctx);
-  const bindState = function(object, name, defaultValue) {
-    const slot = pkg.PropertySlot.create({object, name});
-    if (foam.Undefined.isInstance(slot.get())) slot.set(defaultValue);
-    urlState.addBinding(name, slot);
-    return slot;
-  };
   const clearState = function() { return urlState.clearBindings(); };
 
   return {
     workerEvents,
     apiMatrixController,
     apiConfluence,
-    bindState,
     clearState,
     promises: [],
   };

--- a/lib/client/api_service.es6.js
+++ b/lib/client/api_service.es6.js
@@ -17,7 +17,7 @@ const pkg = org.chromium.apis.web;
 
 // TODO(markdittmer): Use foam.lookup() for class lookup. May also need to shove
 // this into a FOAM class when porting to FOAM classloader.
-angular.module('confluence').service('api', ['$window', function($window) {
+angular.module('confluence').service('api', function() {
   const ctx = foam.box.Context.create({
     myname: '/page',
   });
@@ -58,15 +58,17 @@ angular.module('confluence').service('api', ['$window', function($window) {
   const bindState = function(object, name, defaultValue) {
     const slot = pkg.PropertySlot.create({object, name});
     if (foam.Undefined.isInstance(slot.get())) slot.set(defaultValue);
-    urlState.addSlot(name, slot);
+    urlState.addBinding(name, slot);
     return slot;
   };
+  const clearState = function() { return urlState.clearBindings(); };
 
   return {
     workerEvents,
     apiMatrixController,
     apiConfluence,
     bindState,
+    clearState,
     promises: [],
   };
-}]);
+});

--- a/lib/client/api_service.es6.js
+++ b/lib/client/api_service.es6.js
@@ -55,12 +55,19 @@ angular.module('confluence').service('api', function() {
     }, ctx),
   }, ctx);
   const urlState = foam.web.URLState.create(null, ctx);
+  const bindState = function(object, name, defaultValue) {
+    const slot = pkg.PropertySlot.create({object, name});
+    if (foam.Undefined.isInstance(slot.get())) slot.set(defaultValue);
+    urlState.addBinding(name, slot);
+    return slot;
+  };
   const clearState = function() { return urlState.clearBindings(); };
 
   return {
     workerEvents,
     apiMatrixController,
     apiConfluence,
+    bindState,
     clearState,
     promises: [],
   };

--- a/lib/client/api_service.es6.js
+++ b/lib/client/api_service.es6.js
@@ -12,6 +12,7 @@ require('../web_apis/web_interface.es6.js');
 require('./api_confluence.es6.js');
 require('./api_matrix.es6.js');
 require('./events.es6.js');
+require('./state.es6.js');
 const pkg = org.chromium.apis.web;
 
 // TODO(markdittmer): Use foam.lookup() for class lookup. May also need to shove
@@ -53,11 +54,19 @@ angular.module('confluence').service('api', ['$window', function($window) {
       name: '/worker/apiConfluence'
     }, ctx),
   }, ctx);
+  const urlState = foam.web.URLState.create(null, ctx);
+  const bindState = function(object, name, defaultValue) {
+    const slot = pkg.PropertySlot.create({object, name});
+    if (foam.Undefined.isInstance(slot.get())) slot.set(defaultValue);
+    urlState.addSlot(name, slot);
+    return slot;
+  };
 
   return {
+    workerEvents,
     apiMatrixController,
     apiConfluence,
-    workerEvents: workerEvents,
+    bindState,
     promises: [],
   };
 }]);

--- a/lib/client/state.es6.js
+++ b/lib/client/state.es6.js
@@ -3,6 +3,30 @@
 // found in the LICENSE file.
 'use strict';
 
+// Refine foam.Object.equals to recursively check own object keys. This is
+// necessary for dealing with plain objects in URL state comparisons.
+foam.LIB({
+  name: 'foam.Object',
+
+  methods: [
+    function equals(a, b) {
+      var keys = {};
+      if ( ! foam.Object.isInstance(b) ) return false;
+      for (let key in a) {
+        if (!a.hasOwnProperty(key)) continue;
+        if (!foam.util.equals(a[key], b[key])) return false;
+        keys[key] = true;
+      }
+      for (let key in b) {
+        if (keys[key] || !b.hasOwnProperty(key)) continue;
+        if (!foam.util.equals(a[key], b[key])) return false;
+      }
+      return true;
+    },
+  ],
+});
+
+// Provide a foam.core.internal.PropertySlot implementation for plain objects.
 foam.CLASS({
   name: 'PropertySlot',
   package: 'org.chromium.apis.web',

--- a/lib/client/state.es6.js
+++ b/lib/client/state.es6.js
@@ -1,0 +1,44 @@
+// Copyright 2017 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+'use strict';
+
+foam.CLASS({
+  name: 'PropertySlot',
+  package: 'org.chromium.apis.web',
+  extends: 'foam.core.Slot',
+
+  properties: [
+    {
+      class: 'String',
+      name: 'name',
+      documentation: 'The property name where the slot should be installed.',
+      required: true,
+    },
+    {
+      name: 'object',
+      documentation: 'The object containing the named value.',
+      required: true,
+    },
+    {
+      name: 'value_',
+      documentation: 'Value currently stored in property.'
+    },
+  ],
+
+  methods: [
+    function init() {
+      this.SUPER();
+      this.validate();
+
+      const initialValue = this.object[this.name];
+      Object.defineProperty(this.object, this.name, {
+        get: () => this.get(),
+        set: newValue => this.set(newValue),
+      });
+      this.set(initialValue);
+    },
+    function get() { return this.value_; },
+    function set(newValue) { return this.value_ = newValue; },
+  ]
+});


### PR DESCRIPTION
Attempts to get UI-Router to update key/value data in a sane way without
reloading views have failed. This PR introduces a FOAM-based alternative that
affords:

```js
apiService.bindState($scope, 'propertyNameOnScope', propertyDefaultValue)
```

without destroying the "path part" of the URL hash tracked by UI-Router.

Dependent FOAM PR: https://github.com/foam-framework/foam2/pull/639

This is towards #40