### PR TITLE
Friendly safari versions

### DIFF
--- a/lib/chart/api_velocity_chart.es6.js
+++ b/lib/chart/api_velocity_chart.es6.js
@@ -86,7 +86,7 @@ function apiVelocityChartController($scope, $timeout) {
                   properties: [
                     {
                       name: 'Version',
-                      value: d.browserVersion,
+                      value: d.friendlyBrowserVersion,
                     },
                     {
                       name: 'Total APIs',

--- a/lib/chart/api_velocity_chart.es6.js
+++ b/lib/chart/api_velocity_chart.es6.js
@@ -86,7 +86,7 @@ function apiVelocityChartController($scope, $timeout) {
                   properties: [
                     {
                       name: 'Version',
-                      value: d.friendlyBrowserVersion,
+                      value: d.browserVersion,
                     },
                     {
                       name: 'Total APIs',

--- a/lib/chart/browser_metric_chart.es6.js
+++ b/lib/chart/browser_metric_chart.es6.js
@@ -25,7 +25,7 @@ function browserMetricChartController($scope, $timeout) {
             properties: [
               {
                 name: 'version',
-                value: d.release.browserVersion,
+                value: d.release.friendlyBrowserVersion,
               },
               {
                 name: d.type.label,

--- a/lib/client/api_confluence.es6.js
+++ b/lib/client/api_confluence.es6.js
@@ -87,7 +87,7 @@ foam.CLASS({
                       releaseDate: apiVelocityData.releaseDate.getTime(),
                       browserName: apiVelocityData.browserName,
                       browserVersion:
-                          apiVelocityData.currRelease.browserVersion,
+                          apiVelocityData.currRelease.friendlyBrowserVersion,
                       osName: apiVelocityData.currRelease.osName,
                       osVersion: apiVelocityData.currRelease.osVersion,
                       totalApis: apiVelocityData.totalApis,

--- a/lib/client/api_matrix.es6.js
+++ b/lib/client/api_matrix.es6.js
@@ -54,7 +54,7 @@ foam.CLASS({
           for (let i = 0; i < arraySink.array.length; i++) {
             let release = arraySink.array[i];
             let browserName = release.browserName;
-            let browserVersion = release.browserVersion;
+            let browserVersion = release.friendlyBrowserVersion;
             if (!releases.hasOwnProperty(browserName)) {
               releases[browserName] = {};
             }

--- a/lib/web_apis/release.es6.js
+++ b/lib/web_apis/release.es6.js
@@ -7,6 +7,39 @@ foam.CLASS({
   name: 'Release',
   package: 'org.chromium.apis.web',
   ids: ['releaseKey'],
+
+  constants: {
+    // HACK(markdittmer): A bunch of Safari data were collected before userAgent
+    // scraping fetched the Safari version number (rather than the WebKit
+    // version number). This constant provides version number translation.
+    FRIENDLY_BROWSER_VERSIONS: {
+      Safari: {
+        '534': '5.1',
+        '536': '6.0',
+        '537': '6.1',
+        '537.43': '6.1',
+        '537.71': '7.0',
+        '537.73': '7.0',
+        '537.75': '7.0',
+        '537.76': '7.0',
+        '537.77': '7.0',
+        '537.78': '7.0',
+        '537.85': '7.1',
+        '538': '8.0',
+        '600': '8.0',
+        '601.1': '9.0',
+        '601.2': '9.0',
+        '601.3': '9.0',
+        '601.4': '9.0',
+        '601.5': '9.1',
+        '601.6': '9.1',
+        '601.7': '9.1',
+        '602': '10.0',
+        '603': '10.1',
+      },
+    },
+  },
+
   properties: [
     {
       class: 'String',
@@ -21,6 +54,22 @@ foam.CLASS({
       documentation: `The version of release.`,
       required: true,
       final: true,
+    },
+    {
+      class: 'String',
+      name: 'friendlyBrowserVersion',
+      transient: true,
+      getter: function() {
+        const names = this.FRIENDLY_BROWSER_NAMES;
+        if (!names[this.browserName]) return this.browserVersion;
+        const versionNames = names[this.browserName];
+        const version = this.browserVersion.split('.');
+        for (let i = 1; i <= version.length; i++) {
+          const versionStr = version.slice(0, i).join('.');
+          if (versionNames[versionStr]) return versionNames[versionStr];
+        }
+        return this.browserVersion;
+      }
     },
     {
       class: 'String',

--- a/lib/web_apis/release.es6.js
+++ b/lib/web_apis/release.es6.js
@@ -60,7 +60,7 @@ foam.CLASS({
       name: 'friendlyBrowserVersion',
       transient: true,
       getter: function() {
-        const names = this.FRIENDLY_BROWSER_NAMES;
+        const names = this.FRIENDLY_BROWSER_VERSIONS;
         if (!names[this.browserName]) return this.browserVersion;
         const versionNames = names[this.browserName];
         const version = this.browserVersion.split('.');

--- a/static/component/catalog_table.html
+++ b/static/component/catalog_table.html
@@ -152,7 +152,7 @@
 	<th ng-repeat="release in $ctrl.releases">
 	  <div class="head-cell-container">
 	    <div class="head-text">
-              {{release.browserName}} {{release.browserVersion}}
+              {{release.browserName}} {{release.friendlyBrowserVersion}}
               {{release.osName}} {{release.osVersion}}
 	    </div>
 	    <div class="head-cell-control">


### PR DESCRIPTION
This is towards #4 with a static mapping. It resolves the problem at the UI level. Eventually, the object graph data collection and Datastore should both store Safari (not WebKit) version numbers.