### PR TITLE
Support "dev mode" from `npm run serve`

### DIFF
--- a/lib/dao_container.es6.js
+++ b/lib/dao_container.es6.js
@@ -15,6 +15,19 @@ foam.CLASS({
   BrowserMetricData (aggressive removal, browser-specific, etc.),
   ApiVelocityData (total APIs, new APIs, removed APIs).`,
 
+  requires: [
+    'foam.dao.AdapterDAO',
+    'foam.dao.JDAO',
+    'foam.dao.MDAO',
+    'foam.dao.NodeFileJournal',
+    'foam.dao.ReadOnlyDAO',
+    'foam.version.VersionedClassFactorySingleton',
+    'org.chromium.apis.web.ApiVelocityData',
+    'org.chromium.apis.web.BrowserMetricData',
+    'org.chromium.apis.web.Release',
+    'org.chromium.apis.web.ReleaseWebInterfaceJunction',
+    'org.chromium.apis.web.WebInterface',
+  ],
   exports: [
     'apiVelocityDAO',
     'browserMetricsDAO',
@@ -41,37 +54,71 @@ foam.CLASS({
       class: 'foam.dao.DAOProperty',
       documentation: 'DAO providing access to all known browser releases.',
       name: 'releaseDAO',
-      required: true,
-      final: true,
+      factory: function() { return this.getDAO(this.Release); },
     },
     {
       class: 'foam.dao.DAOProperty',
       documentation: 'DAO providing access to all known web APIs.',
       name: 'webInterfaceDAO',
-      required: true,
-      final: true,
+      factory: function() { return this.getDAO(this.WebInterface); },
     },
     {
       class: 'foam.dao.DAOProperty',
       documentation: `DAO providing access to all browser release <--> API
           relations.`,
       name: 'releaseWebInterfaceJunctionDAO',
-      required: true,
-      final: true,
+      factory: function() {
+        return this.getDAO(this.ReleaseWebInterfaceJunction);
+      },
     },
     {
       class: 'foam.dao.DAOProperty',
       documentation: `DAO providing access to historical browser metrics data.`,
       name: 'browserMetricsDAO',
-      required: true,
-      final: true,
+      factory: function() { return this.getDAO(this.BrowserMetricData); },
     },
     {
       class: 'foam.dao.DAOProperty',
       documentation: `DAO providing access to API Velocity metric data.`,
       name: 'apiVelocityDAO',
-      required: true,
-      final: true,
+      factory: function() { return this.getDAO(this.ApiVelocityData); },
+    },
+    {
+      name: 'versionedClassFactory_',
+      factory: function() {
+        return this.VersionedClassFactorySingleton.create();
+      }
+    },
+  ],
+
+  methods: [
+    function getDAO(cls) {
+      // Get a versioned variant of the requested class.
+      const versionedCls = this.versionedClassFactory_.get(cls);
+
+      // Return a Read-only, adapted-to-unversioned, in-memory DAO that is
+      // bootstrapped from a journal on disk.
+      return this.ReadOnlyDAO.create({
+        delegate: this.AdapterDAO.create({
+          of: cls,
+          to: versionedCls,
+          delegate: this.JDAO.create({
+            of: versionedCls,
+            delegate: this.MDAO.create({of: versionedCls}),
+            journal: this.NodeFileJournal.create({
+              of: versionedCls,
+              fd: this.getDataJournalFD_(versionedCls),
+            }),
+          }),
+        }),
+      });
+    },
+    function getDataJournalFD_(cls) {
+      return require('fs').openSync(
+          require('path').resolve(
+              __dirname,
+              `../data/${cls.id}-journal.js`),
+          'r');
     },
   ],
 });

--- a/lib/datastore/datastore_container.es6.js
+++ b/lib/datastore/datastore_container.es6.js
@@ -280,7 +280,6 @@ foam.CLASS({
   requires: [
     'com.google.cloud.datastore.BatchMutationDatastoreDAO',
     'foam.dao.NoDisjunctionDAO',
-    'foam.version.VersionedClassFactorySingleton',
     'org.chromium.apis.web.ApiVelocityData',
     'org.chromium.apis.web.BrowserMetricData',
     'org.chromium.apis.web.DatastoreContainerMode',
@@ -325,12 +324,6 @@ foam.CLASS({
       factory: function() {
         return this.getDAO(this.ApiVelocityData);
       },
-    },
-    {
-      name: 'versionedClassFactory_',
-      factory: function() {
-        return this.VersionedClassFactorySingleton.create();
-      }
     },
   ],
 

--- a/main/serve.js
+++ b/main/serve.js
@@ -23,17 +23,24 @@ let server = foam.net.node.Server.create({
   port: 8080,
 });
 
-const credentials = JSON.parse(fs.readFileSync(
-    path.resolve(__dirname, '../.local/credentials.json')));
 const logger = foam.log.ConsoleLogger.create();
-const daoContainer = pkg.DatastoreContainer.create({
+let credentials = null;
+try {
+  credentials = require('../.local/credentials.json');
+} catch (e) {
+  logger.warn(`No Cloud Datastore credentails found. Using read-only copy of
+                   local data snapshot`);
+}
+const daoContainer = credentials ? pkg.DatastoreContainer.create({
   mode: pkg.DatastoreContainerMode.WEB_SERVICE,
   gcloudAuthEmail: credentials.client_email,
   gcloudAuthPrivateKey: credentials.private_key,
   gcloudProjectId: credentials.project_id,
   logger: logger,
+}) : pkg.DAOContainer.create({
+  logger: logger,
 });
-const ctx = daoContainer.ctx;
+const ctx = daoContainer.ctx || daoContainer;
 
 function registerDAO(name, dao) {
   foam.assert(dao, 'Broken use of helper: registerDAO()');


### PR DESCRIPTION
If no credentials file is found, setup a `DAOContainer` that uses the local
snapshot.