### PR TITLE
ApiMatrix.toMatrix(): Replace inner junctionDAO.find() with property lookup helper

### DIFF
--- a/lib/client/api_matrix.es6.js
+++ b/lib/client/api_matrix.es6.js
@@ -123,7 +123,6 @@ foam.CLASS({
             // https://github.com/GoogleChrome/confluence/pull/95#discussion_r136720169
             let detached = false;
 
-            let promises = [];
             return this.releaseWebInterfaceJunctionDAO.where(query)
                 .select(this.AnonymousSink.create({
                   sink: {
@@ -135,47 +134,35 @@ foam.CLASS({
                         return;
                       }
 
-                      promises.push(
-                          this.webInterfaceDAO.find(junction.targetId)
-                            .then(iface => {
-                              if (detached) return;
-                              if (id && this.matrixId_ !== id) {
-                                detached = true;
-                                resolve(null);
-                                return;
-                              }
-
-                              const k0 = iface.interfaceName;
-                              const k1 = iface.apiName;
-                              const k2 = junction.sourceId;
-                              // Function and Object's built-in methods can be
-                              // interface name or API name.  So matrix[k0] is
-                              // not sufficient to check if k0 exists in matrix,
-                              // use hasOwnProperty instead.
-                              if (!matrix.hasOwnProperty(k0)) {
-                                matrix[k0] = {};
-                              }
-                              // "hasOwnProperty" could also be a apiName,
-                              // thus use Object.prototype.hasOwnProperty
-                              // to ensure we invoke the right function.
-                              if (!Object.prototype.hasOwnProperty.call(
-                                  matrix[k0], k1)) {
-                                matrix[k0][k1] = {};
-                              }
-                              matrix[k0][k1][k2] = true;
-                            }));
+                      const apiData = this.WebInterface.PROPERTIES_FROM_ID(
+                        junction.targetId);
+                      foam.assert(
+                        foam.String.isInstance(apiData.interfaceName) &&
+                            foam.String.isInstance(apiData.apiName),
+                        `Expected interfaceName and apiName from
+                             WebInterface.id`);
+                      const k0 = apiData.interfaceName;
+                      const k1 = apiData.apiName;
+                      const k2 = junction.sourceId;
+                      // Function and Object's built-in methods can be
+                      // interface name or API name.  So matrix[k0] is
+                      // not sufficient to check if k0 exists in matrix,
+                      // use hasOwnProperty instead.
+                      if (!matrix.hasOwnProperty(k0)) {
+                        matrix[k0] = {};
+                      }
+                      // "hasOwnProperty" could also be a apiName,
+                      // thus use Object.prototype.hasOwnProperty
+                      // to ensure we invoke the right function.
+                      if (!Object.prototype.hasOwnProperty.call(
+                        matrix[k0], k1)) {
+                        matrix[k0][k1] = {};
+                      }
+                      matrix[k0][k1][k2] = true;
                     },
                   },
                 })).then(() => {
                   if (detached) return null;
-                  if (id && this.matrixId_ !== id) {
-                    resolve(null);
-                    return null;
-                  }
-
-                  return Promise.all(promises);
-                }).then(results => {
-                  if (results === null) return null;
                   if (id && this.matrixId_ !== id) {
                     resolve(null);
                     return null;

--- a/lib/client/api_matrix.es6.js
+++ b/lib/client/api_matrix.es6.js
@@ -135,7 +135,7 @@ foam.CLASS({
                       }
 
                       const apiData = this.WebInterface.PROPERTIES_FROM_ID(
-                        junction.targetId);
+                          junction.targetId);
                       foam.assert(
                         foam.String.isInstance(apiData.interfaceName) &&
                             foam.String.isInstance(apiData.apiName),

--- a/lib/web_apis/web_interface.es6.js
+++ b/lib/web_apis/web_interface.es6.js
@@ -7,6 +7,25 @@ foam.CLASS({
   name: 'WebInterface',
   package: 'org.chromium.apis.web',
   ids: ['interfaceKey'],
+
+  // TODO(markdittmer): Really, this is a static method. Upgrade when
+  // https://github.com/foam-framework/foam2/issues/613 is fixed.
+  constants: {
+    // Provide as many property values as possible from id encoding.
+    PROPERTIES_FROM_ID: function(id) {
+      const interfaceKey = id;
+      const apiData = interfaceKey.split('#');
+      foam.assert(
+          apiData.length === 2,
+          'WebInterface.interfaceKey: Expected <interface-name>#<apiName>');
+      return {
+        interfaceKey,
+        interfaceName: apiData[0],
+        apiName: apiData[1],
+      };
+    }
+  },
+
   properties: [
     {
       class: 'String',


### PR DESCRIPTION
This yields astonishing improvements in `toMatrix()` performance.