### PR TITLE
Rework build process

### DIFF
--- a/config/webpack.common.js
+++ b/config/webpack.common.js
@@ -4,35 +4,34 @@
 'use strict';
 
 const path = require('path');
+
 const webpack = require('webpack');
-const ChunkWebpack = webpack.optimize.CommonsChunkPlugin;
+const CleanWebpackPlugin = require('clean-webpack-plugin');
 
-const ROOT_DIR = path.resolve(__dirname, '..');
-const FOAM_DIR = path.resolve(__dirname, '../node_modules/foam2');
-const BUNDLE_DIR = path.resolve(__dirname, '../static/bundle');
-
-const execSync = require('child_process').execSync;
-execSync(`node '${FOAM_DIR}/tools/build.js'  web,gcloud`);
-execSync(`mkdir -p '${ROOT_DIR}/static/bundle'`);
-execSync(`mv '${FOAM_DIR}/foam-bin.js' '${ROOT_DIR}/static/bundle/foam.bundle.js'`);
+const C = require('./webpack.constants.js');
 
 module.exports = {
   entry: {
-    app: [path.resolve(ROOT_DIR, 'main/app.es6')],
-    worker: [path.resolve(ROOT_DIR, 'main/worker.es6')],
+    // Copied in each webpack.<configuration>.js, when FOAM_FLAGS are finalized.
+    foam: [path.resolve(C.ROOT_DIR, '.local/foam-bin')],
+    app: [path.resolve(C.ROOT_DIR, 'main/app.es6')],
   },
   output: {
     filename: '[name].bundle.js',
-    path: BUNDLE_DIR,
+    path: C.BUNDLE_DIR,
   },
   module: {
-    loaders: [
+    rules: [
+      {
+        test: /worker\.(es6\.)?js$/,
+        loader: 'worker-loader',
+        options: {name: '[name].bundle.js'},
+      },
       {
         test: /\.es6\.js$/,
         loader: 'babel-loader',
-        query: {
+        options: {
           presets: ['es2015'],
-          plugins: ['transform-runtime'],
         },
       },
       {
@@ -50,9 +49,16 @@ module.exports = {
     ],
   },
   plugins: [
+    new CleanWebpackPlugin([C.BUNDLE_PROJECT_DIR], {root: C.ROOT_DIR}),
     new webpack.ProvidePlugin({
         'window.$': 'jquery',
         'window.jQuery': 'jquery',
+    }),
+    new webpack.optimize.CommonsChunkPlugin({
+      name: 'vendor',
+      minChunks: function(module) {
+        return module.context && module.context.indexOf('node_modules') !== -1;
+      },
     }),
   ],
   resolve: {

--- a/config/webpack.common.js
+++ b/config/webpack.common.js
@@ -55,7 +55,7 @@ module.exports = {
         'window.jQuery': 'jquery',
     }),
     new webpack.optimize.CommonsChunkPlugin({
-      name: 'vendor',
+      name: 'vendors',
       minChunks: function(module) {
         return module.context && module.context.indexOf('node_modules') !== -1;
       },

--- a/config/webpack.constants.js
+++ b/config/webpack.constants.js
@@ -1,0 +1,24 @@
+// Copyright 2017 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+'use strict';
+
+const path = require('path');
+
+const ROOT_DIR = path.resolve(__dirname, '..');
+const FOAM_DIR = path.resolve(__dirname, '../node_modules/foam2');
+const BUNDLE_PROJECT_DIR = 'static/bundle';
+const BUNDLE_DIR = path.resolve(__dirname, `../${BUNDLE_PROJECT_DIR}`);
+const FOAM_FLAGS = 'web,gcloud';
+const FOAM_BIN_TMP_PATH = `${ROOT_DIR}/.local/foam-bin.js`;
+const FOAM_BIN_REG_EXP = /foam-bin\.js$/;
+
+module.exports = {
+  ROOT_DIR,
+  FOAM_DIR,
+  BUNDLE_PROJECT_DIR,
+  BUNDLE_DIR,
+  FOAM_FLAGS,
+  FOAM_BIN_TMP_PATH,
+  FOAM_BIN_REG_EXP,
+};

--- a/config/webpack.dev.js
+++ b/config/webpack.dev.js
@@ -1,0 +1,27 @@
+// Copyright 2017 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+'use strict';
+
+const merge = require('webpack-merge');
+
+const C = require('./webpack.constants.js');
+const common = require('./webpack.common.js');
+
+const execSync = require('child_process').execSync;
+execSync(`node '${C.FOAM_DIR}/tools/build.js'  ${C.FOAM_FLAGS} ${C.FOAM_BIN_TMP_PATH}`);
+
+module.exports = merge(common, {
+  devtool: 'inline-source-map',
+  module: {
+    rules: [
+      {
+        test: /\.es6\.js$/,
+        loader: 'babel-loader',
+        options: {
+          plugins: ['transform-runtime'],
+        },
+      },
+    ],
+  },
+});

--- a/config/webpack.dev.js
+++ b/config/webpack.dev.js
@@ -9,7 +9,7 @@ const C = require('./webpack.constants.js');
 const common = require('./webpack.common.js');
 
 const execSync = require('child_process').execSync;
-execSync(`node '${C.FOAM_DIR}/tools/build.js'  ${C.FOAM_FLAGS} ${C.FOAM_BIN_TMP_PATH}`);
+execSync(`node '${C.FOAM_DIR}/tools/build.js'  ${C.FOAM_FLAGS} "${C.FOAM_BIN_TMP_PATH}"`);
 
 module.exports = merge(common, {
   devtool: 'inline-source-map',

--- a/config/webpack.prod.js
+++ b/config/webpack.prod.js
@@ -10,7 +10,7 @@ const C = require('./webpack.constants.js');
 const common = require('./webpack.common.js');
 
 const execSync = require('child_process').execSync;
-execSync(`node '${C.FOAM_DIR}/tools/build.js'  ${C.FOAM_FLAGS} ${C.FOAM_BIN_TMP_PATH}`);
+execSync(`node '${C.FOAM_DIR}/tools/build.js'  ${C.FOAM_FLAGS} "${C.FOAM_BIN_TMP_PATH}"`);
 
 module.exports = merge(common, {
   devtool: false,

--- a/config/webpack.prod.js
+++ b/config/webpack.prod.js
@@ -1,0 +1,46 @@
+// Copyright 2017 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+'use strict';
+
+const merge = require('webpack-merge');
+const UglifyJSPlugin = require('uglifyjs-webpack-plugin');
+
+const C = require('./webpack.constants.js');
+const common = require('./webpack.common.js');
+
+const execSync = require('child_process').execSync;
+execSync(`node '${C.FOAM_DIR}/tools/build.js'  ${C.FOAM_FLAGS} ${C.FOAM_BIN_TMP_PATH}`);
+
+module.exports = merge(common, {
+  devtool: false,
+  module: {
+    rules: [
+      {
+        test: C.FOAM_BIN_REG_EXP,
+        use: [
+          {
+            loader: 'babel-loader',
+            options: {
+              comments: false,
+              plugins: [
+                'transform-es2015-block-scoping',
+                'transform-es2015-arrow-functions',
+                'transform-es2015-template-literals',
+                ['transform-es2015-modules-commonjs', {strict: false}],
+              ],
+              parserOpts: {strictMode: false},
+            },
+          },
+        ],
+      },
+    ],
+  },
+  plugins: [
+    new UglifyJSPlugin({
+      compress: {keep_fnames: true},
+      mangle: false,
+      output: {comments: false},
+    }),
+  ],
+});

--- a/lib/client/api_service.es6.js
+++ b/lib/client/api_service.es6.js
@@ -30,8 +30,9 @@ angular.module('confluence').service('api', function() {
   }, ctx);
   registry.register('events', null, workerEventsBox);
 
+  const Worker = require('../../main/worker.es6.js');
   const workerMessagePortBox = foam.box.MessagePortBox.create({
-      target: new Worker('worker.bundle.js'),
+      target: new Worker(),
   }, ctx);
 
   // TODO(markdittmer): This forces the MessagePort handshake to begin

--- a/main/serve.js
+++ b/main/serve.js
@@ -33,7 +33,7 @@ foam.CLASS({
 });
 
 let server = pkg.Server.create({
-  port: 8080,
+  port: 8888,
 });
 
 const logger = foam.log.ConsoleLogger.create();

--- a/main/serve.js
+++ b/main/serve.js
@@ -33,7 +33,7 @@ foam.CLASS({
 });
 
 let server = pkg.Server.create({
-  port: 8888,
+  port: 8080,
 });
 
 const logger = foam.log.ConsoleLogger.create();

--- a/main/worker.es6.js
+++ b/main/worker.es6.js
@@ -4,7 +4,7 @@
 'use strict';
 
 self.window = self.global = self;
-importScripts('foam.bundle.js');
+importScripts('vendor.bundle.js', 'foam.bundle.js');
 
 require('../lib/client/api_confluence.es6.js');
 require('../lib/client/api_matrix.es6.js');

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "coverage": "npm run coverageNode && npm run coverageWeb && istanbul-combine -d .coverage -p summary -r lcov -r html -r json -b . .node_coverage/coverage.json .web_coverage/*/coverage*.json && istanbul check-coverage --config config/istanbul.yml \".coverage/**/coverage*.json\"",
     "coverageNode": "JASMINE_CONFIG_PATH=./config/jasmine.json istanbul cover --config config/istanbul.yml --dir .node_coverage -- jasmine",
     "coverageWeb": "karma start ./config/karma.coverage.conf.js",
+    "deploy": "zsh scripts/deploy.sh",
     "start": "node main/serve.js",
     "serve": "zsh scripts/serve.sh",
     "test": "npm run testNode && npm run testWeb",
@@ -39,8 +40,14 @@
     "babel-core": "^6.23.1",
     "babel-eslint": "^6.1.2",
     "babel-loader": "^6.3.2",
+    "babel-plugin-transform-es2015-arrow-functions": "^6.22.0",
+    "babel-plugin-transform-es2015-block-scoping": "^6.26.0",
+    "babel-plugin-transform-es2015-modules-commonjs": "^6.26.0",
+    "babel-plugin-transform-es2015-template-literals": "^6.22.0",
     "babel-plugin-transform-runtime": "^6.23.0",
-    "babel-preset-es2015": "^6.22.0",
+    "babel-preset-es2015": "^6.22.0"
+    "babel-runtime": "^6.26.0",
+    "clean-webpack-plugin": "^0.1.16",
     "codecov": "^2.1.0",
     "css-loader": "^0.27.3",
     "doctoc": "^1.3.0",
@@ -60,7 +67,10 @@
     "karma-jasmine": "^1.1.0",
     "karma-webpack": "^2.0.2",
     "style-loader": "^0.16.1",
-    "webpack": "^2.2.1"
+    "uglifyjs-webpack-plugin": "^0.4.6",
+    "webpack": "^2.2.1",
+    "webpack-merge": "^4.1.0",
+    "worker-loader": "^0.8.1"
   },
   "eslintConfig": {
     "extends": "google"

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "babel-plugin-transform-es2015-modules-commonjs": "^6.26.0",
     "babel-plugin-transform-es2015-template-literals": "^6.22.0",
     "babel-plugin-transform-runtime": "^6.23.0",
-    "babel-preset-es2015": "^6.22.0"
+    "babel-preset-es2015": "^6.22.0",
     "babel-runtime": "^6.26.0",
     "clean-webpack-plugin": "^0.1.16",
     "codecov": "^2.1.0",

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -8,7 +8,7 @@ RED='\033[0;31m'
 NC='\033[0m'
 
 function win() {
-    printf "\n${GREEN}$1${NC}\n"
+  printf "\n${GREEN}$1${NC}\n"
 }
 
 function warn() {
@@ -28,10 +28,10 @@ pushd "${WD}/../node_modules/foam2"
 FOAM2_VERSION=$(git rev-parse HEAD)
 popd
 
-if [ "${CONFLUENCE_VERSION}" == "${FOAM2_VERSION}" ]; then
+if [ "${CONFLUENCE_VERSION}" = "${FOAM2_VERSION}" ]; then
   error "FOAM2 not not under version control"
   exit 1
-done
+fi
 win "Preparing build for Confluence@${CONFLUENCE_VERSION}, FOAM2@${FOAM2_VERSION}"
 
 webpack --config "${WD}/../config/webpack.prod.js"
@@ -41,6 +41,6 @@ if [ "$?" != "0" ]; then
 fi
 win "Deploying"
 
-gcloud set project web-confluence
-gcloud app deploy --version="confluence-${CONFLUENCE_VERSION}_foam2-${FOAM2_VERSION}"
+gcloud config set project web-confluence
+gcloud app deploy --version="confluence-${CONFLUENCE_VERSION:0:7}--foam2-${FOAM2_VERSION:0:7}"
 win "App deployed!"

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -39,7 +39,7 @@ if [[ "${CONFLUENCE_VERSION}" = "" ]]; then
   error "Main source is not under version control. Is this not a git clone?"
   exit 1
 fi
-if [[ "${CONFLUENCE_VERSION}" = "" || "${CONFLUENCE_VERSION}" = "${FOAM2_VERSION}" ]]; then
+if [[ "${FOAM2_VERSION}" = "" || "${CONFLUENCE_VERSION}" = "${FOAM2_VERSION}" ]]; then
   error "FOAM2 is not under version control. Did you forget to symlink /path/to/foam2 -> node_modules/foam2?"
   exit 1
 fi

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,0 +1,46 @@
+#!/bin/zsh
+
+WD=$(readlink -f $(dirname "$0"))
+
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+RED='\033[0;31m'
+NC='\033[0m'
+
+function win() {
+    printf "\n${GREEN}$1${NC}\n"
+}
+
+function warn() {
+    printf "\n${YELLOW}$1${NC}\n"
+}
+
+function error() {
+    printf "\n${RED}$1${NC}\n"
+}
+
+
+pushd "${WD}/.."
+CONFLUENCE_VERSION=$(git rev-parse HEAD)
+popd
+
+pushd "${WD}/../node_modules/foam2"
+FOAM2_VERSION=$(git rev-parse HEAD)
+popd
+
+if [ "${CONFLUENCE_VERSION}" == "${FOAM2_VERSION}" ]; then
+  error "FOAM2 not not under version control"
+  exit 1
+done
+win "Preparing build for Confluence@${CONFLUENCE_VERSION}, FOAM2@${FOAM2_VERSION}"
+
+webpack --config "${WD}/../config/webpack.prod.js"
+if [ "$?" != "0" ]; then
+  error "webpack failed"
+  exit 1
+fi
+win "Deploying"
+
+gcloud set project web-confluence
+gcloud app deploy --version="confluence-${CONFLUENCE_VERSION}_foam2-${FOAM2_VERSION}"
+win "App deployed!"

--- a/scripts/serve.sh
+++ b/scripts/serve.sh
@@ -35,7 +35,7 @@ function stop() {
 trap stop INT
 
 warn "STARTING WEBPACK"
-webpack --watch --progress --config "${WD}/../config/webpack.config.js" &
+webpack --watch --progress --config "${WD}/../config/webpack.dev.js" &
 Webpack_PID=$!
 win "WEBPACK STARTED (PID=${Webpack_PID})"
 

--- a/static/index.html
+++ b/static/index.html
@@ -13,7 +13,7 @@
 
     <title>Web API Confluence Dashboard</title>
 
-    <script type="text/javascript" src="vendors.bundle.js"></script>
+    <script type="text/javascript" src="vendor.bundle.js"></script>
     <script type="text/javascript" src="foam.bundle.js"></script>
     <script type="text/javascript" src="app.bundle.js"></script>
     <!--Import Google Icon Font-->

--- a/static/index.html
+++ b/static/index.html
@@ -13,7 +13,7 @@
 
     <title>Web API Confluence Dashboard</title>
 
-    <script type="text/javascript" src="vendor.bundle.js"></script>
+    <script type="text/javascript" src="vendors.bundle.js"></script>
     <script type="text/javascript" src="foam.bundle.js"></script>
     <script type="text/javascript" src="app.bundle.js"></script>
     <!--Import Google Icon Font-->


### PR DESCRIPTION
New process allows:

- Separate `dev` and `prod` webpack build configurations
- Minification (to degrees)
- Chunking of vendor code (for now, just one big chunk)
- Worker loading that is compatible with chunking
- Deployment script that captures git hash of Confluence and FOAM2 in version