### PR TITLE
Fixes #165 - Changes overflow:hidden to be horizontal only.

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -26,7 +26,7 @@
         flex-direction: column;
         height: 100vh;
         width: 100vw;
-	overflow: hidden;
+	overflow-x: hidden;
       }
       main {
 	display: flex;


### PR DESCRIPTION
The combination of overflow and defining size of the viewport will clip out the content and then block the scrolling on Firefox Android 57-

