### PR TITLE
Use 0-based y-axis on confluence metrics graphs

### DIFF
--- a/lib/chart/time_series_chart.es6.js
+++ b/lib/chart/time_series_chart.es6.js
@@ -93,10 +93,7 @@ foam.CLASS({
             (apiNumArrary) => {
           return d3.max(apiNumArrary.values, (d) => d.value);
         }) / 20) * 20;
-        let rightAxisLowerBound = Math.floor(d3.min(this.metricSeries,
-            (apiNumArrary) => {
-          return d3.min(apiNumArrary.values, (d) => d.value);
-        }) / 20) * 20;
+        let rightAxisLowerBound = 0;
         // Since the date for each release array is the same.
         let dates = this.metricSeries[0].values.map((d) => d.date);
         // X axis is release date.


### PR DESCRIPTION
This is towards #164