### PR TITLE
ApiExtractor: Gather .prototype's prototypes' properties

### DIFF
--- a/lib/web_catalog/api_extractor.es6.js
+++ b/lib/web_catalog/api_extractor.es6.js
@@ -532,7 +532,7 @@ foam.CLASS({
                 const objectPrototypePropertyId = og.lookup('Object.prototype');
                 let prototypePropertyClassName =
                     this.getClassName_(prototypePropertyId, og);
-                while (prototypePropertyId &&
+                while (!og.isType(prototypePropertyId) &&
                        prototypePropertyId !== objectPrototypePropertyId &&
                        prototypePropertyClassName === className) {
                   prototypePropertyProps = prototypePropertyProps.concat(

--- a/lib/web_catalog/api_extractor.es6.js
+++ b/lib/web_catalog/api_extractor.es6.js
@@ -532,8 +532,7 @@ foam.CLASS({
                     this.getClassName_(prototypePropertyId, og);
                 while (prototypePropertyId &&
                        prototypePropertyId !== objectPrototypePropertyId &&
-                       ((!prototypePropertyClassName) ||
-                        prototypePropertyClassName === 'Object')) {
+                       prototypePropertyClassName === className) {
                   prototypePropertyProps = prototypePropertyProps.concat(
                       this.getObjectProperties_(og, prototypePropertyId));
                   prototypePropertyId = og.getPrototype(prototypePropertyId);


### PR DESCRIPTION
In the edge case of non-Function "libraries" that have a property named "prototype", gather properties from "prototype"'s prototype chain, as long as those properties don't appear to belong to some other interface.