### PR TITLE
Prefer Windows release as basis for metric computations

### DIFF
--- a/lib/confluence/metric_computer_runner.es6.js
+++ b/lib/confluence/metric_computer_runner.es6.js
@@ -86,10 +86,14 @@ foam.CLASS({
                 this.Release.BROWSER_NAME,
                 this.ArraySink.create()))
             .then((groups) => {
-          return groups.groupKeys.map((bName) => {
-            return groups.groups[bName].array[0];
-          });
-        });
+              return groups.groupKeys.map((bName) => {
+                // Prefer Windows release every time.
+                const releases = groups.groups[bName].array;
+                const winReleases = releases
+                      .filter(release => release.osName === 'Windows');
+                return winReleases.length > 0 ? winReleases[0] : releases[0];
+              });
+            });
       },
     },
   ],

--- a/lib/confluence/metric_computer_runner.es6.js
+++ b/lib/confluence/metric_computer_runner.es6.js
@@ -86,9 +86,9 @@ foam.CLASS({
                 this.Release.BROWSER_NAME,
                 this.ArraySink.create()))
             .then((groups) => {
-              return groups.groupKeys.map((bName) => {
+              return groups.groupKeys.map((browserName) => {
                 // Prefer Windows release every time.
-                const releases = groups.groups[bName].array;
+                const releases = groups.groups[browserName].array;
                 const winReleases = releases
                       .filter(release => release.osName === 'Windows');
                 return winReleases.length > 0 ? winReleases[0] : releases[0];


### PR DESCRIPTION
We were getting inaccurate metrics when, by chance, the OSX release of Firefox would be used to calculate some metrics. This ensures that a Windows release is used consistently as the "base release" for metrics computations (except, of course, when there is no Windows release: Safari/WebKit).