### PR TITLE
StatsController for time-to-data-arrival and other things

### DIFF
--- a/lib/client/api_service.es6.js
+++ b/lib/client/api_service.es6.js
@@ -13,6 +13,7 @@ require('./api_confluence.es6.js');
 require('./api_matrix.es6.js');
 require('./events.es6.js');
 require('./state.es6.js');
+require('./stats_controller.es6.js');
 const pkg = org.chromium.apis.web;
 
 // TODO(markdittmer): Use foam.lookup() for class lookup. May also need to shove
@@ -66,9 +67,13 @@ angular.module('confluence').service('api', function() {
   };
   const clearState = function() { return urlState.clearBindings(); };
 
+  const statsController =
+      org.chromium.apis.web.StatsController.create(null, ctx);
+
   return {
     workerEvents,
     apiMatrixController,
+    statsController,
     apiConfluence,
     bindState,
     clearState,

--- a/lib/client/stats_controller.es6.js
+++ b/lib/client/stats_controller.es6.js
@@ -1,0 +1,92 @@
+// Copyright 2017 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+'use strict';
+
+foam.CLASS({
+  package: 'org.chromium.apis.web',
+  name: 'StatsController',
+
+  documentation: `Controller for reporting website statistics.`,
+
+  imports: [
+    'info',
+    'window?',
+  ],
+
+  topics: [
+    'displayMatrix',
+    'mergedDisplayMatrix',
+  ],
+
+  properties: [
+    {
+      class: 'Function',
+      name: 'getTime',
+      factory: function() {
+        return foam.isServer ?
+            require('process').hrtime.bind(require('process')) :
+            this.window.performance.now.bind(this.window.performance);
+      }
+    },
+    {
+      class: 'Function',
+      name: 'reportStat',
+      factory: function() {
+        return function(key, value) {
+          this.info(key, value);
+        };
+      },
+    },
+    {
+      class: 'String',
+      name: 'initialHash',
+      documentation: `URL hash part upon initialization, if applicable.`,
+    },
+  ],
+
+  methods: [
+    function init() {
+      this.SUPER();
+
+      // onDisplayMatrix dispatches 'displayMatrix' to meged listener:
+      // onDisplayMatrix_.
+      this.displayMatrix.sub(this.onDisplayMatrix_);
+      // onDisplayMatrix_ dispatches 'mergedDisplayMatrix' to one-time listener:
+      // initialDisplayMatrix.
+      this.mergedDisplayMatrix.sub(foam.events.oneTime(
+          this.initialDisplayMatrix));
+
+      // Store initial location hash (if not injected). This signals some
+      // listeners as to whether their data are meaningful (i.e., whether the
+      // "right page" was loaded at time=0).
+      if ((!this.initialHash) && this.window && this.window.location) {
+        this.initialHash = this.window.location.hash;
+      }
+    },
+  ],
+
+  listeners: [
+    function onDisplayMatrix(matrix) {
+      const time = this.getTime();
+      this.displayMatrix.pub(matrix, time);
+    },
+    {
+      name: 'onDisplayMatrix_',
+      documentation: `Debounce reporting display matrix for 10s.`,
+      isMerged: true,
+      mergeDelay: 10000,
+      code: function(sub, topic, matrix, time) {
+        this.mergedDisplayMatrix.pub(matrix, time);
+      },
+    },
+    function initialDisplayMatrix(sub, topic, matrix, time) {
+      if (!/^#!\/catalog/.test(this.initialHash)) return;
+      if (Object.keys(matrix).length === 0) {
+        this.reportStat('Initial matrix empty', time);
+      } else {
+        this.reportStat('Initial display matrix', time);
+      }
+    },
+  ],
+});

--- a/lib/client/stats_controller.es6.js
+++ b/lib/client/stats_controller.es6.js
@@ -49,7 +49,7 @@ foam.CLASS({
     function init() {
       this.SUPER();
 
-      // onDisplayMatrix dispatches 'displayMatrix' to meged listener:
+      // onDisplayMatrix dispatches 'displayMatrix' to merged listener:
       // onDisplayMatrix_.
       this.displayMatrix.sub(this.onDisplayMatrix_);
       // onDisplayMatrix_ dispatches 'mergedDisplayMatrix' to one-time listener:
@@ -60,7 +60,7 @@ foam.CLASS({
       // Store initial location hash (if not injected). This signals some
       // listeners as to whether their data are meaningful (i.e., whether the
       // "right page" was loaded at time=0).
-      if ((!this.initialHash) && this.window && this.window.location) {
+      if (!this.initialHash && this.window && this.window.location) {
         this.initialHash = this.window.location.hash;
       }
     },

--- a/lib/component/catalog_table.es6.js
+++ b/lib/component/catalog_table.es6.js
@@ -86,6 +86,7 @@ function catalogTableController($scope, api) {
     $scope.apiCatalogMatrix = matrix;
     setPageLength();
     $scope.$apply();
+    api.statsController.onDisplayMatrix(matrix);
   };
 
   workerEvents.sub(function(_, event) {

--- a/test/any/client/stats_controller-test.es6.js
+++ b/test/any/client/stats_controller-test.es6.js
@@ -1,0 +1,68 @@
+// Copyright 2017 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+'use strict';
+
+describe('StatsController', () => {
+  beforeEach(() => {
+    foam.CLASS({
+      package: 'org.chromium.apis.web.test',
+      name: 'StatsController',
+      extends:   'org.chromium.apis.web.StatsController',
+
+      properties: [
+        {
+          class: 'Boolean',
+          name: 'reported',
+        },
+        {
+          class: 'Function',
+          name: 'reportStat',
+          factory: function() {
+            return function(key, value) {
+              expect(this.reported).toBe(false);
+              this.reported = true;
+            };
+          },
+        },
+      ],
+
+      listeners: [
+        {
+          name: 'onDisplayMatrix_',
+          isMerged: true,
+          mergeDelay: 10,
+          code: function(sub, topic, matrix, time) {
+            this.SUPER(sub, topic, matrix, time);
+          },
+        },
+      ],
+    });
+  });
+
+  it('should record display matrix time exactly once on catalog page', done => {
+    const ctrl = org.chromium.apis.web.test.StatsController.create({
+      initialHash: '#!/catalog',
+    });
+    ctrl.onDisplayMatrix({});
+    ctrl.onDisplayMatrix({});
+    ctrl.onDisplayMatrix({});
+    setTimeout(() => {
+      expect(ctrl.reported).toBe(true);
+      done();
+    }, 30);
+  });
+
+  it('should not record display matrix on non-catalog page', done => {
+    const ctrl = org.chromium.apis.web.test.StatsController.create({
+      initialHash: '#!/confluence',
+    });
+    ctrl.onDisplayMatrix({});
+    ctrl.onDisplayMatrix({});
+    ctrl.onDisplayMatrix({});
+    setTimeout(() => {
+      expect(ctrl.reported).toBe(false);
+      done();
+    }, 30);
+  });
+});

--- a/test/any/files-helper.js
+++ b/test/any/files-helper.js
@@ -41,6 +41,7 @@ beforeAll(function() {
   // Client-side, but used in server integration tests.
   require('../../lib/client/api_matrix.es6.js');
 
+  require('../../lib/client/stats_controller.es6.js');
   require('../../lib/confluence/aggressive_removal.es6.js');
   require('../../lib/confluence/api_velocity.es6.js');
   require('../../lib/confluence/api_velocity_data.es6.js');


### PR DESCRIPTION
Initial metric is time-to-data-arrival on the catalog page. For now, the controller uses `window.location.hash` when it's instantiated to determine whether or not the statistic should apply. This is important because there is no navigation+reload when moving between front page, catalog page, and metrics page. The metric is only reported when the user first loads the page looking at a catalog (and non-empty catalog data eventually arrive).